### PR TITLE
Vokabular für die Deichinformationen-Datensätze

### DIFF
--- a/ontology/fixed_construction.rdf
+++ b/ontology/fixed_construction.rdf
@@ -226,7 +226,7 @@
     <!-- http://rescue-mate.de/ontology/dikeKilometer -->
 
     <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/dikeKilometer">
-        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/FixedConstruction"/>
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/GeographicEntity"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
         <rdfs:label xml:lang="de">Deichkilometer</rdfs:label>
         <rdfs:label xml:lang="en">dike kilometer</rdfs:label>

--- a/ontology/fixed_construction.rdf
+++ b/ontology/fixed_construction.rdf
@@ -348,6 +348,18 @@
     
 
 
+    <!-- http://rescue-mate.de/ontology/DikeDefenseSection -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/DikeDefenseSection">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/GeographicEntity"/>
+        <rdfs:label xml:lang="de">Deichverteidigungsabschnitt</rdfs:label>
+        <rdfs:label xml:lang="en">Dike defense section</rdfs:label>
+        <rdfs:comment xml:lang="de">Abschnitt des Deiches, für den ein bestimmter Deichwart zuständig ist</rdfs:comment>
+        <rdfs:comment xml:lang="en">Section of the dike a particular dike warden is responsible for</rdfs:comment>
+    </owl:Class>
+
+
+
     <!-- http://rescue-mate.de/ontology/DikeKilometerMarker -->
 
     <owl:Class rdf:about="http://rescue-mate.de/ontology/DikeKilometerMarker">
@@ -560,6 +572,18 @@
         <rdfs:label xml:lang="en">Sliding flood gate</rdfs:label>
     </owl:Class>
     
+
+
+    <!-- http://rescue-mate.de/ontology/SeniorDikeWardenDistrict -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/SeniorDikeWardenDistrict">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
+        <rdfs:label xml:lang="de">Oberdeichwart-Bezirk</rdfs:label>
+        <rdfs:label xml:lang="en">Senior dike warden district</rdfs:label>
+        <rdfs:comment xml:lang="de">Organisatorische Untergliederung eines Deichverteidigungsgebietes</rdfs:comment>
+        <rdfs:comment xml:lang="en">Organisational subdivision of a dike defense area</rdfs:comment>
+    </owl:Class>
+
 
 
     <!-- http://rescue-mate.de/ontology/Stoplog -->

--- a/ontology/fixed_construction.rdf
+++ b/ontology/fixed_construction.rdf
@@ -244,6 +244,20 @@
     
 
 
+    <!-- http://rescue-mate.de/ontology/fromDikeKilometer -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/fromDikeKilometer">
+        <rdfs:subPropertyOf rdf:resource="http://rescue-mate.de/ontology/dikeKilometer"/>
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/GeographicEntity"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:label xml:lang="de">von Deichkilometer</rdfs:label>
+        <rdfs:label xml:lang="en">from dike kilometer</rdfs:label>
+        <rdfs:comment xml:lang="de">Deichkilometer, an dem ein Abschnitt beginnt</rdfs:comment>
+        <rdfs:comment xml:lang="en">Dike kilometer at which a section starts</rdfs:comment>
+    </owl:DatatypeProperty>
+
+
+
     <!-- http://rescue-mate.de/ontology/hasSillHeightInMetersAboveSeaLevel -->
 
     <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/hasSillHeightInMetersAboveSeaLevel">
@@ -286,6 +300,20 @@
         <rdfs:label xml:lang="de">zweite Deichsicherheit</rdfs:label>
     </owl:DatatypeProperty>
     
+
+
+    <!-- http://rescue-mate.de/ontology/toDikeKilometer -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/toDikeKilometer">
+        <rdfs:subPropertyOf rdf:resource="http://rescue-mate.de/ontology/dikeKilometer"/>
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/GeographicEntity"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:label xml:lang="de">bis Deichkilometer</rdfs:label>
+        <rdfs:label xml:lang="en">to dike kilometer</rdfs:label>
+        <rdfs:comment xml:lang="de">Deichkilometer, an dem ein Abschnitt endet</rdfs:comment>
+        <rdfs:comment xml:lang="en">Dike kilometer at which a section ends</rdfs:comment>
+    </owl:DatatypeProperty>
+
 
 
     <!-- http://rescue-mate.de/ontology/yearOfConstruction -->

--- a/ontology/fixed_construction.rdf
+++ b/ontology/fixed_construction.rdf
@@ -128,12 +128,23 @@
     <!-- http://rescue-mate.de/ontology/belongsToDikeDefenseArea -->
 
     <owl:ObjectProperty rdf:about="http://rescue-mate.de/ontology/belongsToDikeDefenseArea">
-        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/FixedConstruction"/>
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/GeographicEntity"/>
         <rdfs:range rdf:resource="http://rescue-mate.de/ontology/DikeDefenseArea"/>
         <rdfs:label xml:lang="en">belongs to dike defense area</rdfs:label>
         <rdfs:label xml:lang="de">gehört zu Deichverteidigungsgebiet</rdfs:label>
     </owl:ObjectProperty>
-    
+
+
+
+    <!-- http://rescue-mate.de/ontology/belongsToSeniorDikeWardenDistrict -->
+
+    <owl:ObjectProperty rdf:about="http://rescue-mate.de/ontology/belongsToSeniorDikeWardenDistrict">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/GeographicEntity"/>
+        <rdfs:range rdf:resource="http://rescue-mate.de/ontology/SeniorDikeWardenDistrict"/>
+        <rdfs:label xml:lang="en">belongs to senior dike warden district</rdfs:label>
+        <rdfs:label xml:lang="de">gehört zu Oberdeichwart-Bezirk</rdfs:label>
+    </owl:ObjectProperty>
+
 
 
     <!-- http://rescue-mate.de/ontology/hasEndUserOrganization -->

--- a/ontology/fixed_construction.rdf
+++ b/ontology/fixed_construction.rdf
@@ -320,6 +320,18 @@
     
 
 
+    <!-- http://rescue-mate.de/ontology/DikeKilometerMarker -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/DikeKilometerMarker">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/GeographicEntity"/>
+        <rdfs:label xml:lang="de">Deichkilometer-Marke</rdfs:label>
+        <rdfs:label xml:lang="en">Dike kilometer marker</rdfs:label>
+        <rdfs:comment xml:lang="de">Punkt der Kilometrierung entlang der Hauptdeichlinie</rdfs:comment>
+        <rdfs:comment xml:lang="en">Chainage point along the main dike line</rdfs:comment>
+    </owl:Class>
+
+
+
     <!-- http://rescue-mate.de/ontology/DikeWarden -->
 
     <owl:Class rdf:about="http://rescue-mate.de/ontology/DikeWarden">

--- a/ontology/fixed_construction.rdf
+++ b/ontology/fixed_construction.rdf
@@ -717,6 +717,66 @@
         <rdfs:label xml:lang="de">Wilhelmsburg (Deichverteidigungsgebiet)</rdfs:label>
         <rdfs:label xml:lang="en">Wilhelmsburg (dike defense area)</rdfs:label>
     </owl:NamedIndividual>
+
+
+    <!-- http://rescue-mate.de/resource/finkenwerderSeniorDikeWardenDistrict -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/finkenwerderSeniorDikeWardenDistrict">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/SeniorDikeWardenDistrict"/>
+        <rdfs:label xml:lang="de">Finkenwerder (Oberdeichwart-Bezirk)</rdfs:label>
+        <rdfs:label xml:lang="en">Finkenwerder (senior dike warden district)</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/marschlandeSeniorDikeWardenDistrict -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/marschlandeSeniorDikeWardenDistrict">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/SeniorDikeWardenDistrict"/>
+        <rdfs:label xml:lang="de">Marschlande (Oberdeichwart-Bezirk)</rdfs:label>
+        <rdfs:label xml:lang="en">Marschlande (senior dike warden district)</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/mitteSeniorDikeWardenDistrict -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/mitteSeniorDikeWardenDistrict">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/SeniorDikeWardenDistrict"/>
+        <rdfs:label xml:lang="de">Mitte (Oberdeichwart-Bezirk)</rdfs:label>
+        <rdfs:label xml:lang="en">Mitte (senior dike warden district)</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/suederelbeSeniorDikeWardenDistrict -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/suederelbeSeniorDikeWardenDistrict">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/SeniorDikeWardenDistrict"/>
+        <rdfs:label xml:lang="de">Süderelbe (Oberdeichwart-Bezirk)</rdfs:label>
+        <rdfs:label xml:lang="en">Süderelbe (senior dike warden district)</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/vierlandeSeniorDikeWardenDistrict -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/vierlandeSeniorDikeWardenDistrict">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/SeniorDikeWardenDistrict"/>
+        <rdfs:label xml:lang="de">Vierlande (Oberdeichwart-Bezirk)</rdfs:label>
+        <rdfs:label xml:lang="en">Vierlande (senior dike warden district)</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/wilhelmsburgSeniorDikeWardenDistrict -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/wilhelmsburgSeniorDikeWardenDistrict">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/SeniorDikeWardenDistrict"/>
+        <rdfs:label xml:lang="de">Wilhelmsburg (Oberdeichwart-Bezirk)</rdfs:label>
+        <rdfs:label xml:lang="en">Wilhelmsburg (senior dike warden district)</rdfs:label>
+    </owl:NamedIndividual>
+
 </rdf:RDF>
 
 

--- a/ontology/fixed_construction.rdf
+++ b/ontology/fixed_construction.rdf
@@ -665,6 +665,16 @@
     
 
 
+    <!-- http://rescue-mate.de/resource/veddelDikeDefenseArea -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/veddelDikeDefenseArea">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/DikeDefenseArea"/>
+        <rdfs:label xml:lang="de">Veddel (Deichverteidigungsgebiet)</rdfs:label>
+        <rdfs:label xml:lang="en">Veddel (dike defense area)</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
     <!-- http://rescue-mate.de/resource/wilhelmsburgDikeDefenseArea -->
 
     <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/wilhelmsburgDikeDefenseArea">

--- a/ontology/fixed_construction.rdf
+++ b/ontology/fixed_construction.rdf
@@ -384,6 +384,17 @@
     
 
 
+    <!-- http://rescue-mate.de/ontology/EarthDike -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/EarthDike">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/HydraulicStructure"/>
+        <rdfs:label xml:lang="de">Erddeich</rdfs:label>
+        <rdfs:label xml:lang="en">Earth dike</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://www.wikidata.org/wiki/Q158438"/>
+    </owl:Class>
+
+
+
     <!-- http://rescue-mate.de/ontology/FloodGate -->
 
     <owl:Class rdf:about="http://rescue-mate.de/ontology/FloodGate">
@@ -393,6 +404,16 @@
         <rdfs:seeAlso rdf:resource="https://www.wikidata.org/wiki/Q2345125"/>
     </owl:Class>
     
+
+
+    <!-- http://rescue-mate.de/ontology/FloodProtectionWall -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/FloodProtectionWall">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/HydraulicStructure"/>
+        <rdfs:label xml:lang="de">Hochwasserschutzwand</rdfs:label>
+        <rdfs:label xml:lang="en">Flood protection wall</rdfs:label>
+    </owl:Class>
+
 
 
     <!-- http://rescue-mate.de/ontology/HingedCrestGate -->
@@ -456,6 +477,18 @@
         <rdfs:label xml:lang="de">Manueller Antrieb</rdfs:label>
     </owl:Class>
     
+
+
+    <!-- http://rescue-mate.de/ontology/MainDikeLine -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/MainDikeLine">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/HydraulicStructure"/>
+        <rdfs:label xml:lang="de">Hauptdeichlinie</rdfs:label>
+        <rdfs:label xml:lang="en">Main dike line</rdfs:label>
+        <rdfs:comment xml:lang="de">Abschnitt der durchgehenden Hauptdeichlinie. Instanzen sind die einzelnen kilometrierten Abschnitte, nicht die Linie als Ganzes.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Section of the continuous main dike line. Instances are the individual chainaged sections, not the line as a whole.</rdfs:comment>
+    </owl:Class>
+
 
 
     <!-- http://rescue-mate.de/ontology/Propulsion -->
@@ -540,6 +573,16 @@
         <rdfs:label xml:lang="en">Vertical-lift flood gate</rdfs:label>
     </owl:Class>
     
+
+
+    <!-- http://rescue-mate.de/ontology/WaterManagementFacility -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/WaterManagementFacility">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/HydraulicStructure"/>
+        <rdfs:label xml:lang="de">Wasserwirtschaftliche Anlage</rdfs:label>
+        <rdfs:label xml:lang="en">Water management facility</rdfs:label>
+    </owl:Class>
+
 
 
     <!-- http://rescue-mate.de/ontology/WaterPumpingStation -->

--- a/ontology/hamburg_organizations.rdf
+++ b/ontology/hamburg_organizations.rdf
@@ -225,6 +225,26 @@
     
 
 
+    <!-- http://rescue-mate.de/resource/baHarburgHamburg -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/baHarburgHamburg">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/GermanBoroughOffice"/>
+        <rdfs:label xml:lang="de">Bezirksamt Harburg (Hamburg)</rdfs:label>
+        <rdfs:label xml:lang="en">Bezirksamt Harburg (Hamburg)</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/baMitteHamburg -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/baMitteHamburg">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/GermanBoroughOffice"/>
+        <rdfs:label xml:lang="de">Bezirksamt Hamburg-Mitte (Hamburg)</rdfs:label>
+        <rdfs:label xml:lang="en">Bezirksamt Hamburg-Mitte (Hamburg)</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
     <!-- http://rescue-mate.de/resource/bisHamburg -->
 
     <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/bisHamburg">


### PR DESCRIPTION
Die drei UDP-Datensätze aus den Deichinformationen sind in der Plattform gemergt (rescue-mate-platform!33 Deichkilometer, !32 Hauptdeichlinie, !34 Deichverteidigung). Sie erzeugen RDF, das auf Terme zeigt, die es hier noch nicht gibt. Dieser Branch ergänzt sie.

Vorher wurden die drei Datensätze durchweg auf generische Oberklassen abgebildet, und fachliche Felder landeten als Fließtext in `rdfs:comment` oder als Literal in `dct:type`/`dct:spatial`, weil kein passender Term existierte.

## Neue Klassen

| IRI | Label | Oberklasse | genutzt von |
|---|---|---|---|
| `rmo:DikeKilometerMarker` | Deichkilometer-Marke | `GeographicEntity` | Deichkilometer, 1033 Marken |
| `rmo:MainDikeLine` | Hauptdeichlinie | `HydraulicStructure` | Hauptdeichlinie, 1043 Abschnitte |
| `rmo:EarthDike` | Erddeich | `HydraulicStructure` | Hauptdeichlinie, 774 |
| `rmo:FloodProtectionWall` | Hochwasserschutzwand | `HydraulicStructure` | Hauptdeichlinie, 263 |
| `rmo:WaterManagementFacility` | Wasserwirtschaftliche Anlage | `HydraulicStructure` | Hauptdeichlinie, 6 |
| `rmo:DikeDefenseSection` | Deichverteidigungsabschnitt | `GeographicEntity` | Deichverteidigung, 1043 |
| `rmo:SeniorDikeWardenDistrict` | Oberdeichwart-Bezirk | `BFO_0000006` | Deichverteidigung |

`rmo:MainDikeLine` schließt #1. Die Java-Konstante `RM.MainDikeLine` existierte in der Plattform bereits, nur der Term hier fehlte.

Die drei Anlagentypen fehlten komplett: `RM.getFixedConstructionType` kannte Sperrwerk, Schleuse, Pumpwerk und so weiter, aber weder Erddeich noch Hochwasserschutzwand noch wasserwirtschaftliche Anlage, also genau die drei Typen, aus denen die Hauptdeichlinie besteht.

## Neue Properties

| IRI | Label | Domain | Range |
|---|---|---|---|
| `rmo:fromDikeKilometer` | von Deichkilometer | `GeographicEntity` | `xsd:float` |
| `rmo:toDikeKilometer` | bis Deichkilometer | `GeographicEntity` | `xsd:float` |
| `rmo:belongsToSeniorDikeWardenDistrict` | gehört zu Oberdeichwart-Bezirk | `GeographicEntity` | `SeniorDikeWardenDistrict` |

`fromDikeKilometer` und `toDikeKilometer` sind Unter-Properties von `rmo:dikeKilometer`. Ein Bauwerk liegt bei einem Kilometer, ein Deichabschnitt spannt von einem zum nächsten. Über die gemeinsame Ober-Property lassen sich Kilometermarken und Abschnitte in einer Abfrage verbinden.

## Neue Individuen

- **Deichverteidigungsgebiet Veddel.** Der Lookup kannte nur Harburg, Wilhelmsburg, Innenstadt und Bergedorf. Veddel betrifft 39 Abschnitte der Hauptdeichlinie und wird in der Deichverteidigung gemeinsam mit Innenstadt als "DV-Gebiet III" geführt.
- **Sechs Oberdeichwart-Bezirke**: Finkenwerder, Süderelbe, Wilhelmsburg, Mitte, Marschlande, Vierlande. Sie gliedern die Deichverteidigungsgebiete weiter auf, Gebiet I zerfällt in Finkenwerder und Süderelbe, Gebiet IV in Marschlande und Vierlande.
- **Bezirksamt Harburg und Bezirksamt Hamburg-Mitte.** Beide treten in der Hauptdeichlinie als Träger der Unterhaltungszuständigkeit auf, Bezirksamt Bergedorf gab es schon.

## Zwei erweiterte Domains

`rmo:dikeKilometer` und `rmo:belongsToDikeDefenseArea` hatten beide `FixedConstruction` als Domain und sind jetzt auf `GeographicEntity` erweitert.

Eine Kilometermarke ist kein Bauwerk, ein Deichverteidigungsabschnitt auch nicht. Mit der alten Domain hätte ein Reasoner beide zu Bauwerken gemacht. Da `FixedConstruction` Unterklasse von `GeographicEntity` ist, ist das eine reine Generalisierung: für die bereits im Graph liegenden Bauwerksspezifikationen ändert sich nichts, die Properties werden lediglich auch für die neuen Klassen nutzbar. Die Alternative wären inhaltsgleiche Zweit-Properties gewesen.

## Umfang

Zwei Dateien, 211 Zeilen: `fixed_construction.rdf` und `hamburg_organizations.rdf`. Beide sind wohlgeformt geprüft. In der Plattform sind alle Terme gespiegelt und durch Mapping-Tests gegen die echten UDP-Daten abgedeckt.

Nach dem Merge fehlt für die publizierte Ontologie noch der Weg von `modularized` nach `main` plus ein Release. Dabei sollten `ais.rdf` und `traffic.rdf` in die `owl:imports` von `main.rdf` aufgenommen werden, aktuell sind beide Module verwaist.
