### PR TITLE
Vokabular für die öffentlichen Einrichtungen aus den UDP-Datensätzen

### DIFF
--- a/ontology/main.rdf
+++ b/ontology/main.rdf
@@ -346,6 +346,19 @@
     
 
 
+    <!-- http://rescue-mate.de/ontology/EmergencyShelter -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/EmergencyShelter">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/Facility"/>
+        <rdfs:comment xml:lang="de">Anlage, die im Katastrophenfall zur Unterbringung von Betroffenen genutzt wird</rdfs:comment>
+        <rdfs:comment xml:lang="en">Facility used to accommodate affected people in case of a disaster</rdfs:comment>
+        <rdfs:label xml:lang="de">Notunterkunft</rdfs:label>
+        <rdfs:label xml:lang="en">Emergency shelter</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://www.wikidata.org/wiki/Q1058896"/>
+    </owl:Class>
+
+
+
     <!-- http://rescue-mate.de/ontology/Facility -->
 
     <owl:Class rdf:about="http://rescue-mate.de/ontology/Facility">
@@ -357,6 +370,51 @@
         <rdfs:seeAlso>https://www.wikidata.org/wiki/Q13226383</rdfs:seeAlso>
     </owl:Class>
     
+
+
+    <!-- http://rescue-mate.de/ontology/FireStation -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/FireStation">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/Facility"/>
+        <rdfs:label xml:lang="de">Feuerwache</rdfs:label>
+        <rdfs:label xml:lang="en">Fire station</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://www.wikidata.org/wiki/Q1195942"/>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/ProfessionalFireStation -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/ProfessionalFireStation">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/FireStation"/>
+        <rdfs:comment xml:lang="de">Feuerwache, die von der Berufsfeuerwehr besetzt ist</rdfs:comment>
+        <rdfs:comment xml:lang="en">Fire station staffed by the professional fire brigade</rdfs:comment>
+        <rdfs:label xml:lang="de">Feuer- und Rettungswache der Berufsfeuerwehr</rdfs:label>
+        <rdfs:label xml:lang="en">Professional fire station</rdfs:label>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/VolunteerFireStation -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/VolunteerFireStation">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/FireStation"/>
+        <rdfs:comment xml:lang="de">Feuerwache, die von einer Freiwilligen Feuerwehr besetzt ist</rdfs:comment>
+        <rdfs:comment xml:lang="en">Fire station staffed by a volunteer fire brigade</rdfs:comment>
+        <rdfs:label xml:lang="de">Gerätehaus der Freiwilligen Feuerwehr</rdfs:label>
+        <rdfs:label xml:lang="en">Volunteer fire station</rdfs:label>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/Gymnasium -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/Gymnasium">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/School"/>
+        <rdfs:label xml:lang="de">Gymnasium</rdfs:label>
+        <rdfs:label xml:lang="en">Gymnasium</rdfs:label>
+    </owl:Class>
+
 
 
     <!-- http://rescue-mate.de/ontology/Finding -->
@@ -412,6 +470,28 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
     </owl:Class>
     
+
+
+    <!-- http://rescue-mate.de/ontology/HigherEducationInstitution -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/HigherEducationInstitution">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/Facility"/>
+        <rdfs:label xml:lang="de">Hochschule</rdfs:label>
+        <rdfs:label xml:lang="en">Higher education institution</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://www.wikidata.org/wiki/Q38723"/>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/Hospital -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/Hospital">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/Facility"/>
+        <rdfs:label xml:lang="de">Krankenhaus</rdfs:label>
+        <rdfs:label xml:lang="en">Hospital</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://www.wikidata.org/wiki/Q16917"/>
+    </owl:Class>
+
 
 
     <!-- http://rescue-mate.de/ontology/HumanActivity -->
@@ -546,6 +626,18 @@
     
 
 
+    <!-- http://rescue-mate.de/ontology/LongFormSchool -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/LongFormSchool">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/School"/>
+        <rdfs:comment xml:lang="de">Schule, die Grundschule und weiterführende Schule unter einem Dach führt</rdfs:comment>
+        <rdfs:comment xml:lang="en">School combining primary and secondary education</rdfs:comment>
+        <rdfs:label xml:lang="de">Langformschule</rdfs:label>
+        <rdfs:label xml:lang="en">Long form school</rdfs:label>
+    </owl:Class>
+
+
+
     <!-- http://rescue-mate.de/ontology/Message -->
 
     <owl:Class rdf:about="http://rescue-mate.de/ontology/Message">
@@ -568,6 +660,28 @@
         <rdfs:seeAlso>https://www.wikidata.org/wiki/Q6881760</rdfs:seeAlso>
     </owl:Class>
     
+
+
+    <!-- http://rescue-mate.de/ontology/PoliceStation -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/PoliceStation">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/Facility"/>
+        <rdfs:label xml:lang="de">Polizeikommissariat</rdfs:label>
+        <rdfs:label xml:lang="en">Police station</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://www.wikidata.org/wiki/Q861951"/>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/PrimarySchool -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/PrimarySchool">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/School"/>
+        <rdfs:label xml:lang="de">Grundschule</rdfs:label>
+        <rdfs:label xml:lang="en">Primary school</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://www.wikidata.org/wiki/Q9842"/>
+    </owl:Class>
+
 
 
     <!-- http://rescue-mate.de/ontology/Position -->
@@ -595,6 +709,29 @@
     
 
 
+    <!-- http://rescue-mate.de/ontology/RescuePoint -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/RescuePoint">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/Facility"/>
+        <rdfs:comment xml:lang="de">Festgelegter, ausgeschilderter Treffpunkt, an dem Rettungskräfte Verletzte übernehmen</rdfs:comment>
+        <rdfs:comment xml:lang="en">Signposted meeting point where rescue services take over casualties</rdfs:comment>
+        <rdfs:label xml:lang="de">Rettungspunkt</rdfs:label>
+        <rdfs:label xml:lang="en">Rescue point</rdfs:label>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/School -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/School">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/Facility"/>
+        <rdfs:label xml:lang="de">Schule</rdfs:label>
+        <rdfs:label xml:lang="en">School</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://www.wikidata.org/wiki/Q3914"/>
+    </owl:Class>
+
+
+
     <!-- http://rescue-mate.de/ontology/SensorReading -->
 
     <owl:Class rdf:about="http://rescue-mate.de/ontology/SensorReading">
@@ -619,6 +756,39 @@
     
 
 
+    <!-- http://rescue-mate.de/ontology/SecondarySchool -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/SecondarySchool">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/School"/>
+        <rdfs:comment xml:lang="de">Weiterführende Schule in Hamburg, die alle Abschlüsse bis zum Abitur ermöglicht</rdfs:comment>
+        <rdfs:comment xml:lang="en">Secondary school in Hamburg leading up to the general qualification for university entrance</rdfs:comment>
+        <rdfs:label xml:lang="de">Stadtteilschule</rdfs:label>
+        <rdfs:label xml:lang="en">District school</rdfs:label>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/SpecialNeedsSchool -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/SpecialNeedsSchool">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/School"/>
+        <rdfs:label xml:lang="de">Sonderschule</rdfs:label>
+        <rdfs:label xml:lang="en">Special needs school</rdfs:label>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/SportsHall -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/SportsHall">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/Facility"/>
+        <rdfs:label xml:lang="de">Sporthalle</rdfs:label>
+        <rdfs:label xml:lang="en">Sports hall</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://www.wikidata.org/wiki/Q1076486"/>
+    </owl:Class>
+
+
+
     <!-- http://rescue-mate.de/ontology/Trailer -->
 
     <owl:Class rdf:about="http://rescue-mate.de/ontology/Trailer">
@@ -628,6 +798,17 @@
         <rdfs:seeAlso>https://www.wikidata.org/wiki/Q216146</rdfs:seeAlso>
     </owl:Class>
     
+
+
+    <!-- http://rescue-mate.de/ontology/VocationalSchool -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/VocationalSchool">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/School"/>
+        <rdfs:label xml:lang="de">Berufliche Schule</rdfs:label>
+        <rdfs:label xml:lang="en">Vocational school</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://www.wikidata.org/wiki/Q1044566"/>
+    </owl:Class>
+
 
 
     <!-- http://rescue-mate.de/ontology/Vehicle -->
@@ -651,6 +832,18 @@
         <rdfs:label xml:lang="de">Videoaufnahme</rdfs:label>
     </owl:Class>
     
+
+
+    <!-- http://rescue-mate.de/ontology/WaterRescuePoint -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/WaterRescuePoint">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/RescuePoint"/>
+        <rdfs:comment xml:lang="de">Rettungspunkt an einem Gewässer</rdfs:comment>
+        <rdfs:comment xml:lang="en">Rescue point at a body of water</rdfs:comment>
+        <rdfs:label xml:lang="de">Wasserrettungspunkt</rdfs:label>
+        <rdfs:label xml:lang="en">Water rescue point</rdfs:label>
+    </owl:Class>
+
 
 
     <!-- http://rescue-mate.de/ontology/VolunteeringCampaign -->


### PR DESCRIPTION
Elf offene UDP-Mapping-MRs in der Plattform (rescue-mate-platform!19 bis !31) typisieren zusammen 1437 Objekte als nacktes `rmo:Facility`, weil es nichts Spezifischeres gibt. Eine Feuerwache und eine Sporthalle sind im Graph derzeit dasselbe Ding mit anderem Label, und eine Abfrage wie "alle Krankenhäuser" ist nicht möglich.

`rmo:Facility` hat bislang genau vier Unterklassen, alle vier aus dem Pflegeeinrichtungs-Modul.

## Neue Klassen

Direkt unter `rmo:Facility`:

| IRI | Label | Datensatz | Objekte |
|---|---|---|---|
| `rmo:FireStation` | Feuerwache | Oberklasse | |
| `rmo:ProfessionalFireStation` | Feuer- und Rettungswache der Berufsfeuerwehr | !19 Berufsfeuerwehr | 19 |
| `rmo:VolunteerFireStation` | Gerätehaus der Freiwilligen Feuerwehr | !23 Freiwillige Feuerwehr | 86 |
| `rmo:PoliceStation` | Polizeikommissariat | !20 PK-Standorte | 37 |
| `rmo:HigherEducationInstitution` | Hochschule | !21 Hochschulen | 50 |
| `rmo:Hospital` | Krankenhaus | !24 Krankenhäuser | 37 |
| `rmo:School` | Schule | !25, !26 Schulen | 543 |
| `rmo:RescuePoint` | Rettungspunkt | !28 Rettungspunkte | 106 |
| `rmo:WaterRescuePoint` | Wasserrettungspunkt | !27 Wasserrettungspunkte | 86 |
| `rmo:EmergencyShelter` | Notunterkunft | !29 Notunterkünfte | 58 |
| `rmo:SportsHall` | Sporthalle | !31 Sporthallen | 515 |

`WaterRescuePoint` ist Unterklasse von `RescuePoint`, die beiden Feuerwachen-Typen von `FireStation`.

Unter `rmo:School` die Hamburger Schulformen, wie sie das Feld `kapitelbezeichnung` in beiden Schul-Datensätzen führt:

| IRI | Label |
|---|---|
| `rmo:PrimarySchool` | Grundschule |
| `rmo:SecondarySchool` | Stadtteilschule |
| `rmo:Gymnasium` | Gymnasium |
| `rmo:SpecialNeedsSchool` | Sonderschule |
| `rmo:VocationalSchool` | Berufliche Schule |
| `rmo:LongFormSchool` | Langformschule |

Der Wertebereich ist geschlossen: sechs Werte, in beiden Datensätzen dieselben.

## Was bewusst keine Klasse geworden ist

- **staatlich gegen privat bzw. nicht-staatlich** (Hochschulen `status`, und der Unterschied zwischen !25 und !26). Das ist die Trägerschaft, nicht die Art der Einrichtung. Gehört an eine Property, nicht in die Klassenhierarchie.
- **`art_der_stationaeren_versorgung`** bei den Krankenhäusern (voll-, teil-, voll- und teilstationär). Ebenfalls ein Attribut der Einrichtung, kein eigener Einrichtungstyp.

## Warum in `main.rdf` und nicht in einem eigenen Modul

Ein eigenes Modul wäre der modularen Struktur näher, aber `ais.rdf` und `traffic.rdf` zeigen das Problem: beide werden von keiner Datei importiert, und die Modul-IRIs lösen unter `rescue-mate.de` nicht auf (`fixed_construction/0.6.0` liefert 404). Ein neues Modul wäre damit im geladenen Graphen unsichtbar, denn geladen wird `main.rdf`.

`rmo:Facility` selbst steht ohnehin in `main.rdf`, insofern liegen die Unterklassen dort nicht falsch. Wenn die Modulstruktur später sauber aufgelöst ist, lassen sie sich in einem Rutsch in ein `public_facilities.rdf` verschieben.

## Umfang

Eine Datei, 17 Klassen. Wohlgeformt geprüft, Hierarchie und Labels gegen den geparsten Baum verifiziert.
