### PR TITLE
Vokabular für die Bezirks- und Stadtteil-Datensätze

### DIFF
--- a/ontology/main.rdf
+++ b/ontology/main.rdf
@@ -193,6 +193,50 @@
     
 
 
+    <!-- http://rescue-mate.de/ontology/averageDwellingSizeInSquareMeters -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/averageDwellingSizeInSquareMeters">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/CityDistrict"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:label xml:lang="de">durchschnittliche Wohnungsgröße in Quadratmetern</rdfs:label>
+        <rdfs:label xml:lang="en">average dwelling size in square meters</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/dwellingsInOneAndTwoFamilyHousesInPercent -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/dwellingsInOneAndTwoFamilyHousesInPercent">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/CityDistrict"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:label xml:lang="de">Anteil der Wohnungen in Ein- und Zweifamilienhäusern in Prozent</rdfs:label>
+        <rdfs:label xml:lang="en">dwellings in one and two family houses in percent</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/livingSpacePerResidentInSquareMeters -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/livingSpacePerResidentInSquareMeters">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/CityDistrict"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:label xml:lang="de">Wohnfläche je Einwohner in Quadratmetern</rdfs:label>
+        <rdfs:label xml:lang="en">living space per resident in square meters</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/numberOfDwellings -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/numberOfDwellings">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/CityDistrict"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+        <rdfs:label xml:lang="de">Anzahl der Wohnungen</rdfs:label>
+        <rdfs:label xml:lang="en">number of dwellings</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
     <!-- http://rescue-mate.de/ontology/Activity -->
 
     <owl:Class rdf:about="http://rescue-mate.de/ontology/Activity">
@@ -253,6 +297,19 @@
         <rdfs:seeAlso>https://www.wikidata.org/wiki/Q1150070</rdfs:seeAlso>
     </owl:Class>
     
+
+
+    <!-- http://rescue-mate.de/ontology/CityDistrict -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/CityDistrict">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
+        <rdfs:comment xml:lang="de">Stadtteil als administrative Untergliederung einer Stadt</rdfs:comment>
+        <rdfs:comment xml:lang="en">Administrative subdivision of a city</rdfs:comment>
+        <rdfs:label xml:lang="de">Stadtteil</rdfs:label>
+        <rdfs:label xml:lang="en">City district</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://www.wikidata.org/wiki/Q734818"/>
+    </owl:Class>
+
 
 
     <!-- http://rescue-mate.de/ontology/Container -->
@@ -694,6 +751,18 @@
         <rdfs:label xml:lang="en">Position</rdfs:label>
     </owl:Class>
     
+
+
+    <!-- http://rescue-mate.de/ontology/PoliceDistrict -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/PoliceDistrict">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
+        <rdfs:comment xml:lang="de">Zuständigkeitsgebiet eines Polizeikommissariats</rdfs:comment>
+        <rdfs:comment xml:lang="en">Area of responsibility of a police station</rdfs:comment>
+        <rdfs:label xml:lang="de">Polizeikommissariat-Bezirk</rdfs:label>
+        <rdfs:label xml:lang="en">Police district</rdfs:label>
+    </owl:Class>
+
 
 
     <!-- http://rescue-mate.de/ontology/Reduction -->


### PR DESCRIPTION
Die beiden letzten offenen UDP-Mapping-MRs aus rescue-mate-platform#4 typisieren ihre Objekte als generisches `rmo:GeographicEntity` (!30 PK-Grenzen, !35 Wohnungsstatistik).

Bei !35 kommt ein Fehler dazu: die vier Wohnungs-Kennzahlen werden als `rmr:dwellingCount`, `rmr:singleAndTwoFamilyHouseDwellingSharePercent`, `rmr:livingSpacePerResidentSquareMeters` und `rmr:averageDwellingSizeSquareMeters` abgelegt. Das ist der **Ressourcen-Namensraum** `http://rescue-mate.de/resource/`, in dem Individuen und RML-Funktionen liegen, nicht der Ontologie-Namensraum. Die vier Terme existieren nirgends.

## Neue Klassen

| IRI | Label | Oberklasse | Datensatz |
|---|---|---|---|
| `rmo:CityDistrict` | Stadtteil | `obo:BFO_0000006` (spatial region) | !35, 99 Hamburger Stadtteile |
| `rmo:PoliceDistrict` | Polizeikommissariat-Bezirk | `obo:BFO_0000006` | !30, 241 Grenzflächen |

Beide sind Flächen, keine Objekte, deshalb spatial region und nicht `GeographicEntity`. Das folgt `rmo:DikeDefenseArea` und `rmo:SeniorDikeWardenDistrict`, die genauso modelliert sind.

## Neue Properties

Alle mit Domain `rmo:CityDistrict`, für die vier Dateien der Wohnungsstatistik:

| IRI | Label | Range |
|---|---|---|
| `rmo:numberOfDwellings` | Anzahl der Wohnungen | `xsd:int` |
| `rmo:averageDwellingSizeInSquareMeters` | durchschnittliche Wohnungsgröße in Quadratmetern | `xsd:float` |
| `rmo:livingSpacePerResidentInSquareMeters` | Wohnfläche je Einwohner in Quadratmetern | `xsd:float` |
| `rmo:dwellingsInOneAndTwoFamilyHousesInPercent` | Anteil der Wohnungen in Ein- und Zweifamilienhäusern in Prozent | `xsd:float` |

Die Namen orientieren sich an den vorhandenen Maßeinheits-Properties des Bauwerk-Moduls (`openWaterLevelInMeters`, `clearWidthInMeters`), also Einheit im Namen statt im Wert.

## Ablage

Wie bei #99 in `main.rdf`, aus demselben Grund: ein eigenes Modul wäre im geladenen Graphen unsichtbar, solange die Modul-IRIs nicht auflösen.
