### PR TITLE
Vokabular für Parken, Ladesäulen und Verkehrslage

### DIFF
--- a/ontology/main.rdf
+++ b/ontology/main.rdf
@@ -419,6 +419,282 @@
 
 
 
+    <!-- http://rescue-mate.de/ontology/numberOfParkingSpaces -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/numberOfParkingSpaces">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/ParkingFacility"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+        <rdfs:label xml:lang="de">Anzahl der Stellplätze</rdfs:label>
+        <rdfs:label xml:lang="en">number of parking spaces</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/numberOfFreeParkingSpaces -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/numberOfFreeParkingSpaces">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/ParkingFacility"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+        <rdfs:label xml:lang="de">Anzahl der freien Stellplätze</rdfs:label>
+        <rdfs:label xml:lang="en">number of free parking spaces</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/numberOfAccessibleParkingSpaces -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/numberOfAccessibleParkingSpaces">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/ParkingFacility"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+        <rdfs:label xml:lang="de">Anzahl der Behindertenstellplätze</rdfs:label>
+        <rdfs:label xml:lang="en">number of accessible parking spaces</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/numberOfWomenParkingSpaces -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/numberOfWomenParkingSpaces">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/ParkingFacility"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+        <rdfs:label xml:lang="de">Anzahl der Frauenstellplätze</rdfs:label>
+        <rdfs:label xml:lang="en">number of women parking spaces</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/numberOfCarSharingParkingSpaces -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/numberOfCarSharingParkingSpaces">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/ParkingFacility"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+        <rdfs:label xml:lang="de">Anzahl der Carsharing-Stellplätze</rdfs:label>
+        <rdfs:label xml:lang="en">number of car sharing parking spaces</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/occupancyInPercent -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/occupancyInPercent">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/ParkingFacility"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:label xml:lang="de">Auslastung in Prozent</rdfs:label>
+        <rdfs:label xml:lang="en">occupancy in percent</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/clearanceHeightInMeters -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/clearanceHeightInMeters">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/ParkingFacility"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:label xml:lang="de">Einfahrtshöhe in Metern</rdfs:label>
+        <rdfs:label xml:lang="en">clearance height in meters</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/occupancyObservedAt -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/occupancyObservedAt">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/ParkingFacility"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTimeStamp"/>
+        <rdfs:label xml:lang="de">Belegungsdaten erhoben am</rdfs:label>
+        <rdfs:label xml:lang="en">occupancy observed at</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/numberOfChargingPoints -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/numberOfChargingPoints">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/ChargingStation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+        <rdfs:label xml:lang="de">Anzahl der Ladepunkte</rdfs:label>
+        <rdfs:label xml:lang="en">number of charging points</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/trafficStateObservedAt -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/trafficStateObservedAt">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/WaySegment"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTimeStamp"/>
+        <rdfs:label xml:lang="de">Verkehrszustand erhoben am</rdfs:label>
+        <rdfs:label xml:lang="en">traffic state observed at</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/hasAvailabilityStatus -->
+
+    <owl:ObjectProperty rdf:about="http://rescue-mate.de/ontology/hasAvailabilityStatus">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Facility"/>
+        <rdfs:range rdf:resource="http://rescue-mate.de/ontology/AvailabilityStatus"/>
+        <rdfs:label xml:lang="de">hat Verfügbarkeitsstatus</rdfs:label>
+        <rdfs:label xml:lang="en">has availability status</rdfs:label>
+    </owl:ObjectProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/hasTrafficState -->
+
+    <owl:ObjectProperty rdf:about="http://rescue-mate.de/ontology/hasTrafficState">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/WaySegment"/>
+        <rdfs:range rdf:resource="http://rescue-mate.de/ontology/TrafficState"/>
+        <rdfs:label xml:lang="de">hat Verkehrszustand</rdfs:label>
+        <rdfs:label xml:lang="en">has traffic state</rdfs:label>
+    </owl:ObjectProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/hasRoadCategory -->
+
+    <owl:ObjectProperty rdf:about="http://rescue-mate.de/ontology/hasRoadCategory">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/WaySegment"/>
+        <rdfs:range rdf:resource="http://rescue-mate.de/ontology/RoadCategory"/>
+        <rdfs:label xml:lang="de">hat Straßenklasse</rdfs:label>
+        <rdfs:label xml:lang="en">has road category</rdfs:label>
+    </owl:ObjectProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/ParkingFacility -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/ParkingFacility">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/Facility"/>
+        <rdfs:comment xml:lang="de">Anlage, die dem Abstellen von Fahrzeugen dient</rdfs:comment>
+        <rdfs:comment xml:lang="en">Facility for parking vehicles</rdfs:comment>
+        <rdfs:label xml:lang="de">Parkanlage</rdfs:label>
+        <rdfs:label xml:lang="en">Parking facility</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://www.wikidata.org/wiki/Q6501349"/>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/ParkingGarage -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/ParkingGarage">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/ParkingFacility"/>
+        <rdfs:label xml:lang="de">Parkhaus</rdfs:label>
+        <rdfs:label xml:lang="en">Parking garage</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://www.wikidata.org/wiki/Q170165"/>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/ParkingLot -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/ParkingLot">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/ParkingFacility"/>
+        <rdfs:label xml:lang="de">Parkplatz</rdfs:label>
+        <rdfs:label xml:lang="en">Parking lot</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://www.wikidata.org/wiki/Q6501349"/>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/MultiStoreyParkingDeck -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/MultiStoreyParkingDeck">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/ParkingFacility"/>
+        <rdfs:comment xml:lang="de">Offene, mehrgeschossige Parkanlage ohne vollwertige Gebäudehülle</rdfs:comment>
+        <rdfs:comment xml:lang="en">Open multi storey parking structure without a full building envelope</rdfs:comment>
+        <rdfs:label xml:lang="de">Parkpalette</rdfs:label>
+        <rdfs:label xml:lang="en">Multi storey parking deck</rdfs:label>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/RoadsideParking -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/RoadsideParking">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/ParkingFacility"/>
+        <rdfs:comment xml:lang="de">Parkmöglichkeit am Straßenrand statt in einer eigenen Anlage</rdfs:comment>
+        <rdfs:comment xml:lang="en">Parking at the roadside rather than in a dedicated facility</rdfs:comment>
+        <rdfs:label xml:lang="de">Straßenrandparken</rdfs:label>
+        <rdfs:label xml:lang="en">Roadside parking</rdfs:label>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/ParkAndRideFacility -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/ParkAndRideFacility">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/ParkingFacility"/>
+        <rdfs:comment xml:lang="de">Parkanlage, die dem Umstieg auf den öffentlichen Nahverkehr dient</rdfs:comment>
+        <rdfs:comment xml:lang="en">Parking facility intended for transferring to public transport</rdfs:comment>
+        <rdfs:label xml:lang="de">P+R-Anlage</rdfs:label>
+        <rdfs:label xml:lang="en">Park and ride facility</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://www.wikidata.org/wiki/Q1160590"/>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/ParkingSpace -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/ParkingSpace">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/Facility"/>
+        <rdfs:comment xml:lang="de">Einzelne markierte oder bewirtschaftete Stellplatzfläche im öffentlichen Raum</rdfs:comment>
+        <rdfs:comment xml:lang="en">Individual marked or managed parking area in public space</rdfs:comment>
+        <rdfs:label xml:lang="de">Stellplatzfläche</rdfs:label>
+        <rdfs:label xml:lang="en">Parking space</rdfs:label>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/ChargingStation -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/ChargingStation">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/Facility"/>
+        <rdfs:comment xml:lang="de">Anlage zum Laden von Elektrofahrzeugen</rdfs:comment>
+        <rdfs:comment xml:lang="en">Facility for charging electric vehicles</rdfs:comment>
+        <rdfs:label xml:lang="de">Ladesäule</rdfs:label>
+        <rdfs:label xml:lang="en">Charging station</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://www.wikidata.org/wiki/Q1520890"/>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/AvailabilityStatus -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/AvailabilityStatus">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000019"/>
+        <rdfs:comment xml:lang="de">Zustand der Verfügbarkeit einer Anlage zu einem Zeitpunkt</rdfs:comment>
+        <rdfs:comment xml:lang="en">State of availability of a facility at a point in time</rdfs:comment>
+        <rdfs:label xml:lang="de">Verfügbarkeitsstatus</rdfs:label>
+        <rdfs:label xml:lang="en">Availability status</rdfs:label>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/TrafficState -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/TrafficState">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000019"/>
+        <rdfs:comment xml:lang="de">Zustand des Verkehrsflusses auf einem Streckenabschnitt</rdfs:comment>
+        <rdfs:comment xml:lang="en">State of the traffic flow on a way segment</rdfs:comment>
+        <rdfs:label xml:lang="de">Verkehrszustand</rdfs:label>
+        <rdfs:label xml:lang="en">Traffic state</rdfs:label>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/RoadCategory -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/RoadCategory">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000019"/>
+        <rdfs:comment xml:lang="de">Verkehrliche Einstufung einer Straße</rdfs:comment>
+        <rdfs:comment xml:lang="en">Functional category of a road</rdfs:comment>
+        <rdfs:label xml:lang="de">Straßenklasse</rdfs:label>
+        <rdfs:label xml:lang="en">Road category</rdfs:label>
+    </owl:Class>
+
+
+
     <!-- http://rescue-mate.de/ontology/Activity -->
 
     <owl:Class rdf:about="http://rescue-mate.de/ontology/Activity">
@@ -1143,6 +1419,116 @@
     <rdf:Description rdf:about="http://www.w3.org/ns/prov#Organization">
         <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/JuridicalPerson"/>
     </rdf:Description>
+    <!-- http://rescue-mate.de/resource/availableStatus -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/availableStatus">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/AvailabilityStatus"/>
+        <rdfs:label xml:lang="de">frei</rdfs:label>
+        <rdfs:label xml:lang="en">available</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/occupiedStatus -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/occupiedStatus">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/AvailabilityStatus"/>
+        <rdfs:label xml:lang="de">besetzt</rdfs:label>
+        <rdfs:label xml:lang="en">occupied</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/partiallyOccupiedStatus -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/partiallyOccupiedStatus">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/AvailabilityStatus"/>
+        <rdfs:label xml:lang="de">teilweise belegt</rdfs:label>
+        <rdfs:label xml:lang="en">partially occupied</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/closedStatus -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/closedStatus">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/AvailabilityStatus"/>
+        <rdfs:label xml:lang="de">geschlossen</rdfs:label>
+        <rdfs:label xml:lang="en">closed</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/malfunctionStatus -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/malfunctionStatus">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/AvailabilityStatus"/>
+        <rdfs:label xml:lang="de">Störung</rdfs:label>
+        <rdfs:label xml:lang="en">malfunction</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/unknownStatus -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/unknownStatus">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/AvailabilityStatus"/>
+        <rdfs:label xml:lang="de">unbekannt</rdfs:label>
+        <rdfs:label xml:lang="en">unknown</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/freeFlowingTrafficState -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/freeFlowingTrafficState">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/TrafficState"/>
+        <rdfs:label xml:lang="de">fließend</rdfs:label>
+        <rdfs:label xml:lang="en">free flowing</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/denseTrafficState -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/denseTrafficState">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/TrafficState"/>
+        <rdfs:label xml:lang="de">dicht</rdfs:label>
+        <rdfs:label xml:lang="en">dense</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/majorRoadCategory -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/majorRoadCategory">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/RoadCategory"/>
+        <rdfs:label xml:lang="de">Hauptverkehrsstraße</rdfs:label>
+        <rdfs:label xml:lang="en">major road</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/connectingRoadCategory -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/connectingRoadCategory">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/RoadCategory"/>
+        <rdfs:label xml:lang="de">Verbindungsstraße</rdfs:label>
+        <rdfs:label xml:lang="en">connecting road</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/residentialRoadCategory -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/residentialRoadCategory">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/RoadCategory"/>
+        <rdfs:label xml:lang="de">Anliegerstraße</rdfs:label>
+        <rdfs:label xml:lang="en">residential road</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
 </rdf:RDF>
 
 


### PR DESCRIPTION
Die fünf verbliebenen UDP-Mapping-MRs (rescue-mate-platform!40 bis !44) beschreiben Parkanlagen, Ladesäulen und den Verkehrszustand. Dafür gibt es bisher **gar nichts**: die einzigen einschlägigen Terme sind `rmo:WaySegment` und `rmo:OSMWaySegment`.

## Parken

!41, !42 und !43 beschreiben dieselbe Sache in drei Ausprägungen, deshalb ein gemeinsamer Zweig statt drei Einzelklassen:

```
Facility
├── ParkingFacility          Parkanlage
│   ├── ParkingGarage        Parkhaus
│   ├── ParkingLot           Parkplatz
│   ├── MultiStoreyParkingDeck   Parkpalette
│   ├── RoadsideParking      Straßenrandparken
│   └── ParkAndRideFacility  P+R-Anlage
├── ParkingSpace             Stellplatzfläche
└── ChargingStation          Ladesäule
```

**`ParkAndRideFacility` ist eine eigene Achse.** Die 38 Objekte aus !43 sind je nach Feld `art` Parkhaus, Parkplatz oder Parkpalette **und** P+R-Anlage. Beide Typen werden am selben Objekt vergeben, P+R ist deshalb keine Unterklasse von Parkhaus.

**`ParkingSpace` steht bewusst neben `ParkingFacility`.** !41 liefert einzelne bewirtschaftete Stellplatzflächen am Straßenrand als Polygone, das ist keine Anlage mit Kapazität, sondern eine Fläche.

### Kapazität und Belegung

Alle mit Domain `rmo:ParkingFacility`:

| IRI | Range | Quellfelder |
|---|---|---|
| `numberOfParkingSpaces` | `xsd:int` | `stellplaetze_gesamt`, `gesamt` |
| `numberOfFreeParkingSpaces` | `xsd:int` | `frei`, `stellplaetze_frei` |
| `numberOfAccessibleParkingSpaces` | `xsd:int` | `behindertenst`, `stellplaetze_behinderte_gesamt` |
| `numberOfWomenParkingSpaces` | `xsd:int` | `frauenst`, `stellplaetze_frauen_gesamt` |
| `numberOfCarSharingParkingSpaces` | `xsd:int` | `stellplaetze_carsharing_gesamt` |
| `occupancyInPercent` | `xsd:float` | `auslastung`, `stellpl_frei_in_prozent` |
| `clearanceHeightInMeters` | `xsd:float` | `einfahrtshoehe_in_meter` |
| `occupancyObservedAt` | `xsd:dateTimeStamp` | `received`, `aktualitaet_belegungsdaten` |

## Ladesäulen

`rmo:ChargingStation` plus `rmo:numberOfChargingPoints` für `anzahl_ladepunkte`.

## Verkehrslage

Das Subjekt ist ein Streckenabschnitt, `rmo:WaySegment` gibt es bereits. Neu sind der Zustand und die Straßenklasse, beide als Objekt-Property auf benannte Individuen:

- `rmo:hasTrafficState` → `rmo:TrafficState`, Individuen `freeFlowingTrafficState` (fließend), `denseTrafficState` (dicht)
- `rmo:hasRoadCategory` → `rmo:RoadCategory`, Individuen `majorRoadCategory` (Hauptverkehrsstraße), `connectingRoadCategory` (Verbindungsstraße), `residentialRoadCategory` (Anliegerstraße)
- `rmo:trafficStateObservedAt` für `zeitstempel`

## Verfügbarkeitsstatus

`rmo:hasAvailabilityStatus` → `rmo:AvailabilityStatus` mit den Individuen `availableStatus` (frei), `occupiedStatus` (besetzt), `partiallyOccupiedStatus` (teilweise belegt), `closedStatus` (geschlossen), `malfunctionStatus` (Störung), `unknownStatus` (unbekannt). Deckt `situation` und `status` aus !42 sowie `status` und `ladesaeule_status` aus !44 ab.

Status als Individuen und nicht als Klassen: ein Parkhaus *hat* den Status frei, es *ist* kein Frei-Parkhaus. Analog zu den Deichverteidigungsgebieten.

`AvailabilityStatus`, `TrafficState` und `RoadCategory` hängen unter `obo:BFO_0000019` (quality), es sind Eigenschaften eines Dings, keine Örtlichkeiten.

## Eine bekannte Lücke

Die Wertemenge von `zustandsklasse` ist aus einem 100-Feature-Ausschnitt abgeleitet und enthält dort nur *fließend* und *dicht*. Die Vollmenge dürfte weitere Stufen kennen. Ich habe nichts dazuerfunden; unbekannte Werte laufen wie bei den anderen Lookups in eine Fehlermeldung und erzeugen keinen Typ. Sobald die Vollmenge vorliegt, sind das ein bis zwei zusätzliche Individuen.

## Ablage

Wie bei #99, #100 und #101 in `main.rdf`, damit die Terme im geladenen Graphen ankommen.

Umfang: 11 Klassen, 13 Properties, 11 Individuen. Wohlgeformt geprüft, Hierarchie gegen den geparsten Baum verifiziert.
