### PR TITLE
Parkraum-Vokabular, Wertemengen gegen die Vollmenge abgeglichen

### DIFF
--- a/ontology/main.rdf
+++ b/ontology/main.rdf
@@ -829,6 +829,40 @@
 
 
 
+    <!-- http://rescue-mate.de/ontology/isMarked -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/isMarked">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/ParkingSpace"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
+        <rdfs:label xml:lang="de">ist markiert</rdfs:label>
+        <rdfs:label xml:lang="en">is marked</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/hasPermittedVehicleType -->
+
+    <owl:ObjectProperty rdf:about="http://rescue-mate.de/ontology/hasPermittedVehicleType">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/ParkingSpace"/>
+        <rdfs:range rdf:resource="http://rescue-mate.de/ontology/ParkingVehicleType"/>
+        <rdfs:label xml:lang="de">hat zugelassene Fahrzeugart</rdfs:label>
+        <rdfs:label xml:lang="en">has permitted vehicle type</rdfs:label>
+    </owl:ObjectProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/ParkingVehicleType -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/ParkingVehicleType">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000019"/>
+        <rdfs:comment xml:lang="de">Fahrzeugart, für die eine Stellplatzfläche zugelassen ist</rdfs:comment>
+        <rdfs:comment xml:lang="en">Type of vehicle a parking area is designated for</rdfs:comment>
+        <rdfs:label xml:lang="de">zugelassene Fahrzeugart</rdfs:label>
+        <rdfs:label xml:lang="en">Permitted vehicle type</rdfs:label>
+    </owl:Class>
+
+
+
     <!-- http://rescue-mate.de/ontology/Activity -->
 
     <owl:Class rdf:about="http://rescue-mate.de/ontology/Activity">
@@ -1717,6 +1751,216 @@
 
     <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/unclarifiedRegulation">
         <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingRegulation"/>
+        <rdfs:label xml:lang="de">Klärung</rdfs:label>
+        <rdfs:label xml:lang="en">to be clarified</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/slowMovingTrafficState -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/slowMovingTrafficState">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/TrafficState"/>
+        <rdfs:label xml:lang="de">zäh</rdfs:label>
+        <rdfs:label xml:lang="en">slow moving</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/congestedTrafficState -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/congestedTrafficState">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/TrafficState"/>
+        <rdfs:label xml:lang="de">gestaut</rdfs:label>
+        <rdfs:label xml:lang="en">congested</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/motorwayRoadCategory -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/motorwayRoadCategory">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/RoadCategory"/>
+        <rdfs:label xml:lang="de">Autobahn</rdfs:label>
+        <rdfs:label xml:lang="en">motorway</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/collectiveParkingOrientation -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/collectiveParkingOrientation">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingOrientation"/>
+        <rdfs:label xml:lang="de">Sammelparken</rdfs:label>
+        <rdfs:label xml:lang="en">collective</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/unclarifiedParkingOrientation -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/unclarifiedParkingOrientation">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingOrientation"/>
+        <rdfs:label xml:lang="de">Klärung</rdfs:label>
+        <rdfs:label xml:lang="en">to be clarified</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/unregulatedParkingRegulation -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/unregulatedParkingRegulation">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingRegulation"/>
+        <rdfs:label xml:lang="de">Unbewirtschaftet</rdfs:label>
+        <rdfs:label xml:lang="en">unregulated</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/parkingDiscRegulation -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/parkingDiscRegulation">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingRegulation"/>
+        <rdfs:label xml:lang="de">Parkscheibe</rdfs:label>
+        <rdfs:label xml:lang="en">parking disc</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/absoluteStoppingRegulation -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/absoluteStoppingRegulation">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingRegulation"/>
+        <rdfs:label xml:lang="de">Absolutes Haltverbot</rdfs:label>
+        <rdfs:label xml:lang="en">absolute stopping ban</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/generalAccessibleParkingRegulation -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/generalAccessibleParkingRegulation">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingRegulation"/>
+        <rdfs:label xml:lang="de">Behindertenstellplatz, allgemein</rdfs:label>
+        <rdfs:label xml:lang="en">accessible parking, general</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/personalAccessibleParkingRegulation -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/personalAccessibleParkingRegulation">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingRegulation"/>
+        <rdfs:label xml:lang="de">Behindertenstellplatz, personalisiert</rdfs:label>
+        <rdfs:label xml:lang="en">accessible parking, personalised</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/chargingRegulation -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/chargingRegulation">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingRegulation"/>
+        <rdfs:label xml:lang="de">Laden</rdfs:label>
+        <rdfs:label xml:lang="en">charging</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/loadingZoneRegulation -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/loadingZoneRegulation">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingRegulation"/>
+        <rdfs:label xml:lang="de">Ladezone</rdfs:label>
+        <rdfs:label xml:lang="en">loading zone</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/carSharingRegulation -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/carSharingRegulation">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingRegulation"/>
+        <rdfs:label xml:lang="de">Sharing</rdfs:label>
+        <rdfs:label xml:lang="en">car sharing</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/generalVehicleType -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/generalVehicleType">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingVehicleType"/>
+        <rdfs:label xml:lang="de">Allgemein</rdfs:label>
+        <rdfs:label xml:lang="en">general</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/carVehicleType -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/carVehicleType">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingVehicleType"/>
+        <rdfs:label xml:lang="de">Pkw</rdfs:label>
+        <rdfs:label xml:lang="en">car</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/truckVehicleType -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/truckVehicleType">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingVehicleType"/>
+        <rdfs:label xml:lang="de">Lkw</rdfs:label>
+        <rdfs:label xml:lang="en">truck</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/busVehicleType -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/busVehicleType">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingVehicleType"/>
+        <rdfs:label xml:lang="de">Bus</rdfs:label>
+        <rdfs:label xml:lang="en">bus</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/motorcycleVehicleType -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/motorcycleVehicleType">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingVehicleType"/>
+        <rdfs:label xml:lang="de">Krad</rdfs:label>
+        <rdfs:label xml:lang="en">motorcycle</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/bicycleVehicleType -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/bicycleVehicleType">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingVehicleType"/>
+        <rdfs:label xml:lang="de">Rad</rdfs:label>
+        <rdfs:label xml:lang="en">bicycle</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/electricScooterVehicleType -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/electricScooterVehicleType">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingVehicleType"/>
+        <rdfs:label xml:lang="de">E-Roller</rdfs:label>
+        <rdfs:label xml:lang="en">electric scooter</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/unclarifiedVehicleType -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/unclarifiedVehicleType">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingVehicleType"/>
         <rdfs:label xml:lang="de">Klärung</rdfs:label>
         <rdfs:label xml:lang="en">to be clarified</rdfs:label>
     </owl:NamedIndividual>

--- a/ontology/main.rdf
+++ b/ontology/main.rdf
@@ -695,6 +695,140 @@
 
 
 
+    <!-- http://rescue-mate.de/ontology/isAccessible -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/isAccessible">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/ParkingFacility"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
+        <rdfs:label xml:lang="de">ist barrierefrei</rdfs:label>
+        <rdfs:label xml:lang="en">is accessible</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/walkingDistanceToStationInMeters -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/walkingDistanceToStationInMeters">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/ParkAndRideFacility"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+        <rdfs:label xml:lang="de">Fußweg zur Station in Metern</rdfs:label>
+        <rdfs:label xml:lang="en">walking distance to station in meters</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/travelTimeToCentralStationInMinutes -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/travelTimeToCentralStationInMinutes">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/ParkAndRideFacility"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+        <rdfs:label xml:lang="de">Fahrzeit zum Hauptbahnhof in Minuten</rdfs:label>
+        <rdfs:label xml:lang="en">travel time to central station in minutes</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/dayTicketPriceInEuro -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/dayTicketPriceInEuro">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/ParkAndRideFacility"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:label xml:lang="de">Tagesticketpreis in Euro</rdfs:label>
+        <rdfs:label xml:lang="en">day ticket price in euro</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/monthlyTicketPriceInEuro -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/monthlyTicketPriceInEuro">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/ParkAndRideFacility"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:label xml:lang="de">Monatsticketpreis in Euro</rdfs:label>
+        <rdfs:label xml:lang="en">monthly ticket price in euro</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/annualTicketPriceInEuro -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/annualTicketPriceInEuro">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/ParkAndRideFacility"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:label xml:lang="de">Jahresticketpreis in Euro</rdfs:label>
+        <rdfs:label xml:lang="en">annual ticket price in euro</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/servedByPublicTransportLine -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/servedByPublicTransportLine">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/ParkAndRideFacility"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:label xml:lang="de">angebunden an Linie</rdfs:label>
+        <rdfs:label xml:lang="en">served by public transport line</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/hasParkingOrientation -->
+
+    <owl:ObjectProperty rdf:about="http://rescue-mate.de/ontology/hasParkingOrientation">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/ParkingSpace"/>
+        <rdfs:range rdf:resource="http://rescue-mate.de/ontology/ParkingOrientation"/>
+        <rdfs:label xml:lang="de">hat Aufstellart</rdfs:label>
+        <rdfs:label xml:lang="en">has parking orientation</rdfs:label>
+    </owl:ObjectProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/hasParkingRegulation -->
+
+    <owl:ObjectProperty rdf:about="http://rescue-mate.de/ontology/hasParkingRegulation">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/ParkingSpace"/>
+        <rdfs:range rdf:resource="http://rescue-mate.de/ontology/ParkingRegulation"/>
+        <rdfs:label xml:lang="de">hat Bewirtschaftungsart</rdfs:label>
+        <rdfs:label xml:lang="en">has parking regulation</rdfs:label>
+    </owl:ObjectProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/UndergroundCarPark -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/UndergroundCarPark">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/ParkingFacility"/>
+        <rdfs:label xml:lang="de">Tiefgarage</rdfs:label>
+        <rdfs:label xml:lang="en">Underground car park</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://www.wikidata.org/wiki/Q1364150"/>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/ParkingOrientation -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/ParkingOrientation">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000019"/>
+        <rdfs:comment xml:lang="de">Ausrichtung der Stellplätze zur Fahrbahn</rdfs:comment>
+        <rdfs:comment xml:lang="en">Orientation of the parking spaces relative to the road</rdfs:comment>
+        <rdfs:label xml:lang="de">Aufstellart</rdfs:label>
+        <rdfs:label xml:lang="en">Parking orientation</rdfs:label>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/ParkingRegulation -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/ParkingRegulation">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000019"/>
+        <rdfs:comment xml:lang="de">Art der Bewirtschaftung einer Stellplatzfläche</rdfs:comment>
+        <rdfs:comment xml:lang="en">Way a parking area is regulated</rdfs:comment>
+        <rdfs:label xml:lang="de">Bewirtschaftungsart</rdfs:label>
+        <rdfs:label xml:lang="en">Parking regulation</rdfs:label>
+    </owl:Class>
+
+
+
     <!-- http://rescue-mate.de/ontology/Activity -->
 
     <owl:Class rdf:about="http://rescue-mate.de/ontology/Activity">
@@ -1525,6 +1659,66 @@
         <rdf:type rdf:resource="http://rescue-mate.de/ontology/RoadCategory"/>
         <rdfs:label xml:lang="de">Anliegerstraße</rdfs:label>
         <rdfs:label xml:lang="en">residential road</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/parallelParkingOrientation -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/parallelParkingOrientation">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingOrientation"/>
+        <rdfs:label xml:lang="de">längs</rdfs:label>
+        <rdfs:label xml:lang="en">parallel</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/perpendicularParkingOrientation -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/perpendicularParkingOrientation">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingOrientation"/>
+        <rdfs:label xml:lang="de">quer</rdfs:label>
+        <rdfs:label xml:lang="en">perpendicular</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/angleParkingOrientation -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/angleParkingOrientation">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingOrientation"/>
+        <rdfs:label xml:lang="de">schräg</rdfs:label>
+        <rdfs:label xml:lang="en">angle</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/parkingTicketRegulation -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/parkingTicketRegulation">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingRegulation"/>
+        <rdfs:label xml:lang="de">Parkschein</rdfs:label>
+        <rdfs:label xml:lang="en">parking ticket</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/restrictedStoppingRegulation -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/restrictedStoppingRegulation">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingRegulation"/>
+        <rdfs:label xml:lang="de">Eingeschränktes Haltverbot</rdfs:label>
+        <rdfs:label xml:lang="en">restricted stopping</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/unclarifiedRegulation -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/unclarifiedRegulation">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ParkingRegulation"/>
+        <rdfs:label xml:lang="de">Klärung</rdfs:label>
+        <rdfs:label xml:lang="en">to be clarified</rdfs:label>
     </owl:NamedIndividual>
 
 


### PR DESCRIPTION
Nachtrag zu #102, für rescue-mate-platform!41, !42 und !43.

## Vorbemerkung: die Wertemengen stammen jetzt aus der Quelle, nicht aus dem Ausschnitt

Die mitgelieferten Testdateien enthalten nur 100 Features. Ich habe die Wertemengen deshalb über die UDP-API gegen die **Vollmenge** geprüft, also 203.283 Parkraum-, 23.876 Verkehrslage-, 3.008 Ladesäulen-, 127 Parkhaus- und 38 P+R-Objekte. Das hat zwei meiner früheren Aussagen widerlegt:

- **`markierung` ist nicht konstant.** Im Ausschnitt steht 100x "nein", in der Vollmenge 180.297x "nein" und **22.982x "ja"**.
- **`fahrzeugtyp` ist nicht konstant.** Im Ausschnitt 100x "Allgemein", in der Vollmenge zusätzlich Krad, Bus, Lkw, Rad, E-Roller und Kombinationen wie "Bus;Pkw".

Beide sind jetzt modelliert statt weggelassen.

## Vollständige Wertemengen

**Verkehrszustand** (#102 kannte zwei von vier):

| Wert | Individuum | Anzahl |
|---|---|---|
| fliessend | `freeFlowingTrafficState` | 19.595 |
| dicht | `denseTrafficState` | 3.848 |
| **zäh** | `slowMovingTrafficState` | 378 |
| **gestaut** | `congestedTrafficState` | 55 |

**Straßenklasse** (#102 kannte drei von fünf):

| Wert | Individuum | Anzahl |
|---|---|---|
| unbekannt | keine Kategorie, siehe unten | 12.516 |
| Hauptverkehrsstraße | `majorRoadCategory` | 4.234 |
| Anliegerstraße | `residentialRoadCategory` | 3.596 |
| Verbindungsstraße | `connectingRoadCategory` | 3.513 |
| **Autobahn** | `motorwayRoadCategory` | 17 |

"unbekannt" betrifft über die Hälfte der Abschnitte. Das wird kein Individuum, sondern führt zu keiner Kategorie, und zwar ohne Fehlermeldung im Log, sonst würde der Import 12.516 Fehlerzeilen schreiben.

**Aufstellart** (#102 kannte drei von fünf): längs 157.668, schräg 23.143, quer 21.357, **Klärung** 876, **Sammelparken** 238.

**Bewirtschaftungsart** (#102 kannte drei von elf):

| Wert | Individuum | Anzahl |
|---|---|---|
| Unbewirtschaftet | `unregulatedParkingRegulation` | 118.129 |
| Parkschein | `parkingTicketRegulation` | 68.227 |
| Parkscheibe | `parkingDiscRegulation` | 6.115 |
| Eingeschränktes Haltverbot | `restrictedStoppingRegulation` | 3.714 |
| Klärung | `unclarifiedRegulation` | 2.251 |
| Absolutes Haltverbot | `absoluteStoppingRegulation` | 2.029 |
| Behindertenstellplatz, allgemein | `generalAccessibleParkingRegulation` | 922 |
| Behindertenstellplatz, personalisiert | `personalAccessibleParkingRegulation` | 795 |
| Laden | `chargingRegulation` | 685 |
| Sharing | `carSharingRegulation` | 273 |
| Ladezone | `loadingZoneRegulation` | 143 |

Der mit Abstand häufigste Wert, "Unbewirtschaftet", fehlte im Ausschnitt komplett.

Eine Auslegung, die du prüfen solltest: **"Laden" habe ich als Elektro-Laden gedeutet**, nicht als Ladezone für Güter, weil "Ladezone" als eigener Wert daneben steht.

**Zugelassene Fahrzeugart**, neu: Allgemein, Pkw, Lkw, Bus, Krad, Rad, E-Roller, Klärung. Die Quelle liefert Kombinationen mit Semikolon ("Bus;Pkw"), das Mapping wird sie aufteilen und je Fahrzeugart ein Tripel erzeugen.

**Verfügbarkeitsstatus** aus #102 deckt die Vollmenge ab: `frei`, `besetzt`/`belegt`, `teilweise belegt`, `geschlossen`, `Störung`, `unbekannt`/`keine Auslastungsdaten`.

**Parkanlagentyp**: `art` hat in der Vollmenge Parkhaus 77, Parkplatz 24, **Tiefgarage** 22, Straßenrand 3, und einmal "parkhaus" klein geschrieben. Der Lookup normalisiert auf Kleinschreibung, das ist also abgedeckt.

## Neu in diesem PR

3 Klassen (`UndergroundCarPark`, `ParkingOrientation`, `ParkingRegulation`, `ParkingVehicleType`), 11 Properties und 27 Individuen.

Damit sollten für die fünf Datensätze keine weiteren Vokabular-PRs nötig sein.
