### PR TITLE
Add vocabulary for unmanned aerial vehicle flight data

### DIFF
--- a/ontology/ais.rdf
+++ b/ontology/ais.rdf
@@ -132,17 +132,6 @@
     
 
 
-    <!-- http://rescue-mate.de/ontology/headingAtPositionInDegrees -->
-
-    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/headingAtPositionInDegrees">
-        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Position"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <rdfs:label xml:lang="de">Richtung in Grand an Position</rdfs:label>
-        <rdfs:label xml:lang="en">heading at position in degrees</rdfs:label>
-    </owl:DatatypeProperty>
-    
-
-
     <!-- http://rescue-mate.de/ontology/highPositionAccuracy -->
 
     <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/highPositionAccuracy">
@@ -150,16 +139,6 @@
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
         <rdfs:label xml:lang="en">high position accuracy</rdfs:label>
         <rdfs:label xml:lang="de">hohe Positionsgenauigkeit</rdfs:label>
-    </owl:DatatypeProperty>
-    
-
-
-    <!-- http://rescue-mate.de/ontology/positionIndex -->
-
-    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/positionIndex">
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"/>
-        <rdfs:label xml:lang="de">Positionsindex</rdfs:label>
-        <rdfs:label xml:lang="en">position index</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -195,17 +174,6 @@
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
         <rdfs:label xml:lang="de">Speizialmanöver wird an Position durchgeführt</rdfs:label>
         <rdfs:label xml:lang="en">special manoeuvre is performed at position</rdfs:label>
-    </owl:DatatypeProperty>
-    
-
-
-    <!-- http://rescue-mate.de/ontology/speedOverGroundAtPosition -->
-
-    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/speedOverGroundAtPosition">
-        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Position"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#double"/>
-        <rdfs:label xml:lang="de">Geschwindigkeit über Grund an Position</rdfs:label>
-        <rdfs:label xml:lang="en">speed over ground at position</rdfs:label>
     </owl:DatatypeProperty>
     
 

--- a/ontology/main.rdf
+++ b/ontology/main.rdf
@@ -137,6 +137,19 @@
     
 
 
+    <!-- http://rescue-mate.de/ontology/hasFlight -->
+
+    <owl:ObjectProperty rdf:about="http://rescue-mate.de/ontology/hasFlight">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Aircraft"/>
+        <rdfs:range rdf:resource="http://rescue-mate.de/ontology/Flight"/>
+        <rdfs:comment xml:lang="de">Beziehung zwischen einem Luftfahrzeug und einem von ihm durchgeführten Flug</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relation between an aircraft and a flight performed by it</rdfs:comment>
+        <rdfs:label xml:lang="en">has flight</rdfs:label>
+        <rdfs:label xml:lang="de">hat Flug</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://rescue-mate.de/ontology/hasOperator -->
 
     <owl:ObjectProperty rdf:about="http://rescue-mate.de/ontology/hasOperator">
@@ -169,6 +182,119 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    
+
+
+    <!-- http://rescue-mate.de/ontology/hasTrajectory -->
+
+    <owl:ObjectProperty rdf:about="http://rescue-mate.de/ontology/hasTrajectory">
+        <rdfs:range rdf:resource="http://rescue-mate.de/ontology/Trajectory"/>
+        <rdfs:comment xml:lang="de">Beziehung zwischen einem Objekt oder einer Tätigkeit und dem dabei zurückgelegten Weg. Ohne Definitionsbereich, da sowohl Fahrzeuge als auch Tätigkeiten wie ein Flug eine Trajektorie haben können.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relation between an object or an activity and the path travelled. Without a domain, since both vehicles and activities such as a flight can have a trajectory.</rdfs:comment>
+        <rdfs:label xml:lang="en">has trajectory</rdfs:label>
+        <rdfs:label xml:lang="de">hat Trajektorie</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://rescue-mate.de/ontology/headingAtPositionInDegrees -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/headingAtPositionInDegrees">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Position"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:comment xml:lang="de">Ausrichtung des Fahrzeugs an einer Position in Grad, rechtweisend von Nord</rdfs:comment>
+        <rdfs:comment xml:lang="en">Orientation of the vehicle at a position in degrees, true bearing from north</rdfs:comment>
+        <rdfs:label xml:lang="de">Richtung in Grad an Position</rdfs:label>
+        <rdfs:label xml:lang="en">heading at position in degrees</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://rescue-mate.de/ontology/positionIndex -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/positionIndex">
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"/>
+        <rdfs:label xml:lang="de">Positionsindex</rdfs:label>
+        <rdfs:label xml:lang="en">position index</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://rescue-mate.de/ontology/speedOverGroundAtPosition -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/speedOverGroundAtPosition">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Position"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#double"/>
+        <rdfs:comment xml:lang="de">Geschwindigkeit über Grund an einer Position. Achtung: Die Einheit ist durch dieses Prädikat nicht festgelegt; die AIS-Integration trägt hier Knoten ein. Für Quellen mit metrischen Einheiten ist speedOverGroundInMetersPerSecond zu verwenden.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Speed over ground at a position. Note: the unit is not determined by this predicate; the AIS integration writes knots here. For sources with metric units use speedOverGroundInMetersPerSecond.</rdfs:comment>
+        <rdfs:label xml:lang="de">Geschwindigkeit über Grund an Position</rdfs:label>
+        <rdfs:label xml:lang="en">speed over ground at position</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://rescue-mate.de/ontology/altitudeInMetersAboveSeaLevel -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/altitudeInMetersAboveSeaLevel">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Position"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:comment xml:lang="de">Höhe einer Position über Normalhöhennull. Die einzige Höhenangabe, die sich unmittelbar mit Gelände-, Deich- und Pegeldaten vergleichen lässt.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Altitude of a position above sea level. The only altitude that can be compared directly with terrain, dike and water level data.</rdfs:comment>
+        <rdfs:label xml:lang="de">Höhe in Metern über Normalhöhennull</rdfs:label>
+        <rdfs:label xml:lang="en">altitude in meters above sea level</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://rescue-mate.de/ontology/altitudeInMetersAboveTakeoff -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/altitudeInMetersAboveTakeoff">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Position"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:comment xml:lang="de">Höhe einer Position über dem Startpunkt des Fluges. Anschaulich als Flughöhe, ohne Kenntnis des Startpunktes aber nicht mit Kartendaten vergleichbar.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Altitude of a position above the take-off point of the flight. Intuitive as a flight altitude, but not comparable with map data unless the take-off point is known.</rdfs:comment>
+        <rdfs:label xml:lang="de">Höhe in Metern über dem Startpunkt</rdfs:label>
+        <rdfs:label xml:lang="en">altitude in meters above takeoff</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://rescue-mate.de/ontology/batteryRemainingInPercent -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/batteryRemainingInPercent">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Vehicle"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+        <rdfs:comment xml:lang="de">Verbleibende Akkuladung eines Fahrzeugs in Prozent. Bestimmt bei unbemannten Systemen die verbleibende Einsatzdauer.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Remaining battery charge of a vehicle in percent. For unmanned systems this determines the remaining time of operation.</rdfs:comment>
+        <rdfs:label xml:lang="de">verbleibende Akkuladung in Prozent</rdfs:label>
+        <rdfs:label xml:lang="en">battery remaining in percent</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://rescue-mate.de/ontology/elapsedTimeSinceBootInSeconds -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/elapsedTimeSinceBootInSeconds">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Position"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:comment xml:lang="de">Zeit seit dem Start des aufzeichnenden Systems. Monoton und unabhängig von der Systemuhr, daher als Ordnungskriterium auch dann tragfähig, wenn die Uhr nachträglich korrigiert wird.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Time elapsed since the recording system was started. Monotonic and independent of the system clock, hence usable for ordering even when the clock is corrected afterwards.</rdfs:comment>
+        <rdfs:label xml:lang="de">verstrichene Zeit seit Systemstart in Sekunden</rdfs:label>
+        <rdfs:label xml:lang="en">elapsed time since boot in seconds</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://rescue-mate.de/ontology/gnssFixTypeCode -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/gnssFixTypeCode">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Position"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+        <rdfs:comment xml:lang="de">Art der satellitengestützten Ortung als Code gemäß MAVLink GPS_FIX_TYPE, etwa 3 für dreidimensionale Ortung oder 6 für RTK mit fester Mehrdeutigkeitslösung. Beschreibt die Verlässlichkeit der Position.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Type of satellite based positioning as a code according to MAVLink GPS_FIX_TYPE, e.g. 3 for a three dimensional fix or 6 for RTK with fixed ambiguity resolution. Describes how reliable the position is.</rdfs:comment>
+        <rdfs:label xml:lang="de">Art der GNSS-Ortung als Code</rdfs:label>
+        <rdfs:label xml:lang="en">GNSS fix type code</rdfs:label>
+    </owl:DatatypeProperty>
     
 
 
@@ -327,6 +453,32 @@
         <rdfs:label xml:lang="de">Straßensperrung</rdfs:label>
     </owl:Class>
 
+
+
+    <!-- http://rescue-mate.de/ontology/numberOfVisibleSatellites -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/numberOfVisibleSatellites">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Position"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+        <rdfs:comment xml:lang="de">Anzahl der zum Zeitpunkt der Ortung sichtbaren Navigationssatelliten.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Number of navigation satellites visible at the time of positioning.</rdfs:comment>
+        <rdfs:label xml:lang="de">Anzahl sichtbarer Satelliten</rdfs:label>
+        <rdfs:label xml:lang="en">number of visible satellites</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://rescue-mate.de/ontology/speedOverGroundInMetersPerSecond -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/speedOverGroundInMetersPerSecond">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Position"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:comment xml:lang="de">Geschwindigkeit über Grund an einer Position in Metern je Sekunde. Die Einheit steht bewusst im Namen, da Geschwindigkeiten je nach Quelle auch in Knoten geführt werden.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Speed over ground at a position in meters per second. The unit is part of the name on purpose, since depending on the source speeds are also given in knots.</rdfs:comment>
+        <rdfs:label xml:lang="de">Geschwindigkeit über Grund in Metern je Sekunde</rdfs:label>
+        <rdfs:label xml:lang="en">speed over ground in meters per second</rdfs:label>
+    </owl:DatatypeProperty>
+    
 
 
     <!-- http://rescue-mate.de/ontology/WaySegment -->
@@ -876,6 +1028,19 @@
     
 
 
+    <!-- http://rescue-mate.de/ontology/Flight -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/Flight">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/Activity"/>
+        <rdfs:comment xml:lang="de">Tätigkeit eines Luftfahrzeugs vom Abheben bis zur Landung. Fasst die zugehörigen Positionen unabhängig davon zusammen, über wie viele Aufzeichnungsabschnitte sie verteilt sind.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Activity of an aircraft from take-off until landing. Groups the associated positions regardless of how many recording segments they are spread over.</rdfs:comment>
+        <rdfs:label xml:lang="de">Flug</rdfs:label>
+        <rdfs:label xml:lang="en">Flight</rdfs:label>
+        <rdfs:seeAlso>https://www.wikidata.org/wiki/Q206021</rdfs:seeAlso>
+    </owl:Class>
+    
+
+
     <!-- http://rescue-mate.de/ontology/Agent -->
 
     <owl:Class rdf:about="http://rescue-mate.de/ontology/Agent">
@@ -895,6 +1060,19 @@
         <rdfs:seeAlso>https://www.wikidata.org/wiki/Q11436</rdfs:seeAlso>
         <rdfs:label xml:lang="en">Aircraft</rdfs:label>
         <rdfs:label xml:lang="de">Luftfahrzeug</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://rescue-mate.de/ontology/UnmannedAerialVehicle -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/UnmannedAerialVehicle">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/Aircraft"/>
+        <rdfs:comment xml:lang="de">Luftfahrzeug ohne Besatzung an Bord, ferngesteuert oder autonom fliegend</rdfs:comment>
+        <rdfs:comment xml:lang="en">Aircraft without crew on board, either remotely piloted or flying autonomously</rdfs:comment>
+        <rdfs:label xml:lang="de">Unbemanntes Luftfahrzeug</rdfs:label>
+        <rdfs:label xml:lang="en">Unmanned aerial vehicle</rdfs:label>
+        <rdfs:seeAlso>https://www.wikidata.org/wiki/Q484000</rdfs:seeAlso>
     </owl:Class>
     
 
@@ -1375,6 +1553,19 @@
         <rdfs:comment xml:lang="de">Ein Raum-Zeit-Bereich mit einem nulldimensionalen temporalen Anteil (d.h., einem Zeitpunkt) und einem nulldimensionalen räumlichen Anteil (d.h. ein räumlicher Punkt), der also insgesamt einen Raum-Zeit-Punkt darstellt.</rdfs:comment>
         <rdfs:label xml:lang="de">Position</rdfs:label>
         <rdfs:label xml:lang="en">Position</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://rescue-mate.de/ontology/Trajectory -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/Trajectory">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000011"/>
+        <rdfs:comment xml:lang="de">Der von einem bewegten Objekt zurückgelegte Weg, gegeben als zeitlich geordnete Folge von Positionen</rdfs:comment>
+        <rdfs:comment xml:lang="en">The path travelled by a moving object, given as a temporally ordered sequence of positions</rdfs:comment>
+        <rdfs:label xml:lang="de">Trajektorie</rdfs:label>
+        <rdfs:label xml:lang="en">Trajectory</rdfs:label>
+        <rdfs:seeAlso>https://www.wikidata.org/wiki/Q193139</rdfs:seeAlso>
     </owl:Class>
     
 


### PR DESCRIPTION
Ergänzt das Vokabular, mit dem sich ein Drohnenflug im Knowledge Graph so darstellen lässt, wie die AIS-Integration heute schon Schiffsbahnen darstellt — mit dem Ziel, dass **eine** Abfrage beide Spuren findet.

Anlass war ein realer Testflug (30.07.2026, 16 Minuten in der Luft, 9.458 Positionen), dessen MAVLink-Telemetrie in die Plattform soll.

## Neu in `main.rdf`

**Klassen**
- `UnmannedAerialVehicle` unter `Aircraft` — dort hängen bisher nur die bemannten Rettungshubschrauber `NEH` und `RTH`. Ohne eigene Klasse wäre eine Drohne von diesen nicht zu unterscheiden.
- `Flight` unter `Activity`
- `Trajectory` unter `BFO_0000011`, also neben `Position`

**Objekt-Eigenschaften:** `hasFlight`, `hasTrajectory`

**Daten-Eigenschaften:** `altitudeInMetersAboveSeaLevel`, `altitudeInMetersAboveTakeoff`, `elapsedTimeSinceBootInSeconds`, `gnssFixTypeCode`, `numberOfVisibleSatellites`, `speedOverGroundInMetersPerSecond`, `batteryRemainingInPercent`

## Umzug aus `ais.rdf`

`headingAtPositionInDegrees`, `positionIndex` und `speedOverGroundAtPosition` wandern nach `main.rdf`. Alle drei haben `Position` als Definitionsbereich und nichts Maritimes an sich — aber `main.rdf` importiert `ais.rdf` nicht, nur umgekehrt. Damit waren sie für jede andere Quelle unerreichbar. Keine IRI ändert sich, `ais.rdf` importiert `main`, es bricht also nichts.

Nebenbei korrigiert: Tippfehler im deutschen Label von `headingAtPositionInDegrees` („Grand" → „Grad").

## Entscheidungen, über die sich streiten lässt

**Warum eine eigene `Trajectory` und nicht `vai:Trajectory`?** Die VesselAI-Klasse ist maritim. Für ein Luftfahrzeug ist sie sachlich falsch, und solange Schiff und Drohne verschiedene Bahn-Begriffe nutzen, braucht der Viewer zwei Codepfade für dieselbe Frage. Die Umstellung der Schiffe auf den gemeinsamen Begriff wäre ein Folgeschritt und ist hier nicht enthalten.

**Warum zwei Höhen?** MAVLink liefert vier; zwei davon sind EKF-interne Bezugssysteme und bleiben draußen. Über NN ist die einzige, die sich mit Deich-, Gelände- und Pegeldaten vergleichen lässt — bei einem Sturmflutprojekt die eigentlich interessante. Über dem Startpunkt kommt mit, weil sie „wie hoch fliegt das Ding gerade" ohne Umrechnung beantwortet. Zur Einordnung: Der Startpunkt dieses Fluges lag auf 0,74 m über NN.

*Vorbehalt:* Die MSL-Höhe des GPS bezieht sich auf ein globales Geoidmodell, deutsche Höhen auf NHN. Dazwischen liegt ein systematischer Versatz im Dezimeterbereich. Für die Kartendarstellung unerheblich, für „über oder unter Deichkrone" nicht.

**Warum ein zweites Geschwindigkeits-Prädikat?** `speedOverGroundAtPosition` legt keine Einheit fest, und die AIS-Integration trägt dort **Knoten** ein, während MAVLink **m/s** liefert. Das Prädikat auf metrisch umzudefinieren würde vorhandene Daten stillschweigend umdeuten. Deshalb behält es seine Bedeutung und bekommt einen Kommentar, der die Einheitenfrage benennt; metrische Quellen nutzen `speedOverGroundInMetersPerSecond`. Dass `speedOverGroundAtPosition` langfristig eine Einheit im Namen braucht, ist ein eigenes Thema.

**Warum `elapsedTimeSinceBootInSeconds`?** Weil die Wanduhr nicht verlässlich ist. Im ausgewerteten Flug ist die Uhr des Bordrechners **mitten im Schwebeflug** um 56 Jahre vorgerückt, als NTP griff — der Flug liegt dadurch in drei Aufzeichnungsdateien mit zwei Zeitrechnungen. Die Laufzeit des Autopiloten lief monoton durch und ist das einzige belastbare Ordnungskriterium. `positionIndex` wäre die Alternative, taugt hier aber nicht: Bei einem gleitenden Zeitfenster verschiebt sich der Index desselben Punktes zwischen zwei Abrufen.

**Warum hat `hasTrajectory` keinen Definitionsbereich?** Sowohl ein Fahrzeug als auch eine Tätigkeit wie ein Flug kann eine Bahn haben. `BFO_0000030` (Objekt) würde `Flight` fälschlich ausschließen.

## Geprüft

- Beide Dateien parsen als RDF/XML. In `main.rdf` **kein einziges bestehendes Tripel entfernt** (0 entfernt, 101 neu); in `ais.rdf` genau die 14 Tripel der drei umgezogenen Definitionen weniger, keine verwaisten Referenzen.
- Alle referenzierten Klassen (`Activity`, `Aircraft`, `Position`, `Vehicle`) existieren.
- Ein RML-Mapping für den Drohnen-Exporter wurde gegen die **echte carml-Engine** des `rescue-mate-node` laufen gelassen (mit `RmlFunctions`): 3.222 Tripel aus 189 Bahnpunkten, und **jeder erzeugte `rmo:`-Term ist durch diesen PR definiert**.
- Eine SPARQL-Abfrage im Stil der bestehenden Schiffs-Abfrage liefert daraus den vollständigen, zeitlich sortierten Flugpfad inklusive Höhenfilter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
