### PR TITLE
Define the predicates the AIS integration writes, and fix numeric ranges

### DIFF
--- a/ontology/ais.rdf
+++ b/ontology/ais.rdf
@@ -156,6 +156,19 @@
     
 
 
+    <!-- http://rescue-mate.de/ontology/rateOfTurnAtPosition -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/rateOfTurnAtPosition">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Position"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:comment xml:lang="de">Drehrate an einer Position. Ein negativer Wert bedeutet eine Drehung nach Backbord, ein positiver nach Steuerbord. Anders als rateOfTurn, das eine Eigenschaft des Fahrzeugs ist, gehoert dieser Wert zu einem einzelnen Bahnpunkt.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Rate of turn at a position. A negative value indicates a turn to port, a positive one to starboard. Unlike rateOfTurn, which is a property of the vehicle, this value belongs to a single track point.</rdfs:comment>
+        <rdfs:label xml:lang="de">Drehrate an der Position</rdfs:label>
+        <rdfs:label xml:lang="en">rate of turn at position</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
     <!-- http://rescue-mate.de/ontology/receivedAt -->
 
     <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/receivedAt">

--- a/ontology/main.rdf
+++ b/ontology/main.rdf
@@ -197,6 +197,32 @@
     
 
 
+    <!-- http://rescue-mate.de/ontology/latestPosition -->
+
+    <owl:ObjectProperty rdf:about="http://rescue-mate.de/ontology/latestPosition">
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000030"/>
+        <rdfs:range rdf:resource="http://rescue-mate.de/ontology/Position"/>
+        <rdfs:comment xml:lang="de">Verweist auf die juengste bekannte Position eines Objekts. Abkuerzung, damit der aktuelle Standort ohne Sortierung ueber alle Positionen zu finden ist.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Points to the most recent known position of an object. A shortcut, so that the current location can be found without sorting over all positions.</rdfs:comment>
+        <rdfs:label xml:lang="en">latest position</rdfs:label>
+        <rdfs:label xml:lang="de">juengste Position</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://rescue-mate.de/ontology/oldestPosition -->
+
+    <owl:ObjectProperty rdf:about="http://rescue-mate.de/ontology/oldestPosition">
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000030"/>
+        <rdfs:range rdf:resource="http://rescue-mate.de/ontology/Position"/>
+        <rdfs:comment xml:lang="de">Verweist auf die aelteste noch vorgehaltene Position eines Objekts und markiert damit den Anfang der bekannten Spur.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Points to the oldest position still held for an object, marking the beginning of the known track.</rdfs:comment>
+        <rdfs:label xml:lang="en">oldest position</rdfs:label>
+        <rdfs:label xml:lang="de">aelteste Position</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://rescue-mate.de/ontology/headingAtPositionInDegrees -->
 
     <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/headingAtPositionInDegrees">
@@ -237,7 +263,7 @@
 
     <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/altitudeInMetersAboveSeaLevel">
         <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Position"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#double"/>
         <rdfs:comment xml:lang="de">Höhe einer Position über Normalhöhennull. Die einzige Höhenangabe, die sich unmittelbar mit Gelände-, Deich- und Pegeldaten vergleichen lässt.</rdfs:comment>
         <rdfs:comment xml:lang="en">Altitude of a position above sea level. The only altitude that can be compared directly with terrain, dike and water level data.</rdfs:comment>
         <rdfs:label xml:lang="de">Höhe in Metern über Normalhöhennull</rdfs:label>
@@ -250,7 +276,7 @@
 
     <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/altitudeInMetersAboveTakeoff">
         <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Position"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#double"/>
         <rdfs:comment xml:lang="de">Höhe einer Position über dem Startpunkt des Fluges. Anschaulich als Flughöhe, ohne Kenntnis des Startpunktes aber nicht mit Kartendaten vergleichbar.</rdfs:comment>
         <rdfs:comment xml:lang="en">Altitude of a position above the take-off point of the flight. Intuitive as a flight altitude, but not comparable with map data unless the take-off point is known.</rdfs:comment>
         <rdfs:label xml:lang="de">Höhe in Metern über dem Startpunkt</rdfs:label>
@@ -276,7 +302,7 @@
 
     <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/elapsedTimeSinceBootInSeconds">
         <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Position"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#double"/>
         <rdfs:comment xml:lang="de">Zeit seit dem Start des aufzeichnenden Systems. Monoton und unabhängig von der Systemuhr, daher als Ordnungskriterium auch dann tragfähig, wenn die Uhr nachträglich korrigiert wird.</rdfs:comment>
         <rdfs:comment xml:lang="en">Time elapsed since the recording system was started. Monotonic and independent of the system clock, hence usable for ordering even when the clock is corrected afterwards.</rdfs:comment>
         <rdfs:label xml:lang="de">verstrichene Zeit seit Systemstart in Sekunden</rdfs:label>
@@ -472,7 +498,7 @@
 
     <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/speedOverGroundInMetersPerSecond">
         <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Position"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#double"/>
         <rdfs:comment xml:lang="de">Geschwindigkeit über Grund an einer Position in Metern je Sekunde. Die Einheit steht bewusst im Namen, da Geschwindigkeiten je nach Quelle auch in Knoten geführt werden.</rdfs:comment>
         <rdfs:comment xml:lang="en">Speed over ground at a position in meters per second. The unit is part of the name on purpose, since depending on the source speeds are also given in knots.</rdfs:comment>
         <rdfs:label xml:lang="de">Geschwindigkeit über Grund in Metern je Sekunde</rdfs:label>


### PR DESCRIPTION
Zwei lose Enden aus dem UAV-Vokabular-PR.

## Numerische Ranges

`altitudeInMetersAboveSeaLevel`, `altitudeInMetersAboveTakeoff`, `elapsedTimeSinceBootInSeconds` und `speedOverGroundInMetersPerSecond` standen auf `xsd:float`. An unserem eigenen Virtuoso gemessen:

| Datentyp | Darstellung von 3,58 |
|---|---|
| `xsd:double` | `3.58` |
| `xsd:float` | `3.579999923706055` |
| `xsd:decimal` | `3.58` |

Das benachbarte `speedOverGroundAtPosition` nutzt bereits `double`, alle vier ziehen jetzt nach. Aufgefallen ist es, als der erste echte Flug im Graphen landete und die Höhen mit zwanzig Nachkommastellen zurückkamen.

## Fehlende Prädikate

Die AIS-Integration schreibt drei Terme, die nirgends definiert waren:

**`latestPosition`** und **`oldestPosition`** — verweisen auf die jüngste beziehungsweise älteste vorgehaltene Position eines Objekts. Sie kommen nach `main.rdf` neben `hasPosition` und teilen dessen Domain, denn nichts daran ist maritim: Eine Drohne hat eine jüngste Position genau wie ein Schiff.

**`rateOfTurnAtPosition`** — kommt nach `ais.rdf` in die `...AtPosition`-Familie neben `courseOverGroundAtPosition` und `speedOverGroundAtPosition`.

Dabei ist eine Merkwürdigkeit aufgefallen, die ich nicht angefasst habe: `ais.rdf` führt bereits ein `rateOfTurn` mit Domain `Watercraft`, das niemand schreibt. Die beiden sind keine Duplikate — das eine beschreibt das Fahrzeug, das andere einen einzelnen Bahnpunkt. Ob das fahrzeugbezogene bleiben soll, wäre eigens zu entscheiden.

## Stand danach

Von den 53 `rmo:`-Termen, die der Generator referenziert, ist nur noch `aisValid` undefiniert — und das steht ausschließlich in auskommentiertem Code und wird nie geschrieben.

## Geprüft

Beide Dateien parsen. In `main.rdf` sind die vier entfernten Tripel genau die vier alten `rdfs:range`-Angaben, in `ais.rdf` wurde nichts entfernt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
