### PR TITLE
Add a measurements module for stations, sensors and readings

### DIFF
--- a/ontology/main.rdf
+++ b/ontology/main.rdf
@@ -32,6 +32,7 @@
         <owl:imports rdf:resource="http://rescue-mate.de/ontology/social_media/0.6.0"/>
         <owl:imports rdf:resource="http://rescue-mate.de/ontology/events/0.6.0"/>
         <owl:imports rdf:resource="http://rescue-mate.de/ontology/care_facilities/0.6.0"/>
+        <owl:imports rdf:resource="http://rescue-mate.de/ontology/measurements/0.6.0"/>
         <owl:imports rdf:resource="http://www.w3.org/ns/prov-o-inverses-20130430"/>
         <owl:imports rdf:resource="https://w3id.org/function/ontology/1.0.0"/>
         <cc:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
@@ -1779,7 +1780,7 @@
 
     <owl:Class rdf:about="http://rescue-mate.de/ontology/SensorReading">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000109"/>
-        <rdfs:comment xml:lang="en">A sensor reading is a mesurement datum that is a recording of the output of a sensor.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A sensor reading is a measurement datum that is a recording of the output of a sensor.</rdfs:comment>
         <rdfs:comment xml:lang="de">Ein Sensormesswert ist ein Messwert, der auf der Ausgabe eines Sensors basiert.</rdfs:comment>
         <rdfs:label xml:lang="en">Sensor reading</rdfs:label>
         <rdfs:label xml:lang="de">Sensormesswert</rdfs:label>

--- a/ontology/measurements.rdf
+++ b/ontology/measurements.rdf
@@ -1,0 +1,679 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://rescue-mate.de/ontology/"
+     xml:base="http://rescue-mate.de/ontology/"
+     xmlns:cc="http://creativecommons.org/ns#"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:ns="http://www.w3.org/2003/06/sw-vocab-status/ns#"
+     xmlns:dct="http://purl.org/dc/terms/"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:bibo="http://purl.org/ontology/bibo/"
+     xmlns:core="http://purl.org/vocab/frbr/core#"
+     xmlns:foaf="http://xmlns.com/foaf/0.1/"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+     xmlns:vann="http://purl.org/vocab/vann/"
+     xmlns:schema="http://schema.org/"
+     xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
+     xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
+    <owl:Ontology rdf:about="http://rescue-mate.de/ontology/measurements">
+        <owl:versionIRI rdf:resource="http://rescue-mate.de/ontology/measurements/0.6.0"/>
+        <owl:imports rdf:resource="http://rescue-mate.de/ontology/wikidata-bridge/0.6.0"/>
+        <cc:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
+        <dct:created>2026-08-17</dct:created>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2026-08-17</dct:issued>
+        <dct:modified>2026-08-17</dct:modified>
+        <dct:rights xml:lang="en">CC BY 4.0 - RESCUE-MATE Project</dct:rights>
+        <dct:title xml:lang="en">RESCUE-MATE Ontology - Measurements</dct:title>
+        <dct:title xml:lang="de">RESCUE-MATE-Ontologie - Messdaten</dct:title>
+        <rdfs:comment xml:lang="de">Ontologie-Modul für Messstellen, Sensoren und Messwerte. Das Modul ist quellenneutral gehalten: es beschreibt ein Messnetz allgemein, nicht eine bestimmte Quelle, damit hydrologische, meteorologische und andere Messreihen über dieselbe Abfrage erreichbar sind. Erste Quelle ist HydroOnline der Hamburg Port Authority.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Ontology module for measuring stations, sensors and sensor readings. The module is deliberately source neutral: it describes a measuring network in general rather than one particular source, so that hydrological, meteorological and other time series can be reached through a single query pattern. Its first source is the Hamburg Port Authority's HydroOnline.</rdfs:comment>
+        <owl:priorVersion rdf:resource="http://rescue-mate.de/ontology/main/0.5.0"/>
+        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.6</owl:versionInfo>
+    </owl:Ontology>
+
+
+
+    <!--
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+
+
+
+    <!-- http://creativecommons.org/ns#license -->
+
+    <owl:AnnotationProperty rdf:about="http://creativecommons.org/ns#license"/>
+
+
+
+    <!-- http://purl.org/dc/terms/created -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/created"/>
+
+
+
+    <!-- http://purl.org/dc/terms/issued -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/issued"/>
+
+
+
+    <!-- http://purl.org/dc/terms/modified -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/modified"/>
+
+
+
+    <!-- http://purl.org/dc/terms/rights -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/rights"/>
+
+
+
+    <!-- http://purl.org/dc/terms/title -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/title"/>
+
+
+
+    <!--
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+
+
+
+    <!-- http://rescue-mate.de/ontology/hasSensor -->
+
+    <owl:ObjectProperty rdf:about="http://rescue-mate.de/ontology/hasSensor">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/MeasuringStation"/>
+        <rdfs:range rdf:resource="http://rescue-mate.de/ontology/Sensor"/>
+        <rdfs:comment xml:lang="de">Verbindet eine Messstelle mit einem der Sensoren, die dort messen. Eine Messstelle trägt in der Regel mehrere Sensoren, auch mehrere für dieselbe Messgröße.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a measuring station to one of the sensors installed there. A station usually carries several sensors, including several for the same observed property.</rdfs:comment>
+        <rdfs:label xml:lang="de">hat Sensor</rdfs:label>
+        <rdfs:label xml:lang="en">has sensor</rdfs:label>
+    </owl:ObjectProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/hasTendency -->
+
+    <owl:ObjectProperty rdf:about="http://rescue-mate.de/ontology/hasTendency">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/SensorReading"/>
+        <rdfs:range rdf:resource="http://rescue-mate.de/ontology/WaterLevelTendency"/>
+        <rdfs:comment xml:lang="de">Richtung, in die sich der Wasserstand zum Zeitpunkt der Messung bewegt. Wird nur angegeben, wenn die Quelle sie bestimmen konnte.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Direction in which the water level is moving at the time of the reading. Only stated when the source was able to determine it.</rdfs:comment>
+        <rdfs:label xml:lang="de">hat Tendenz</rdfs:label>
+        <rdfs:label xml:lang="en">has tendency</rdfs:label>
+    </owl:ObjectProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/hasVerticalDatum -->
+
+    <owl:ObjectProperty rdf:about="http://rescue-mate.de/ontology/hasVerticalDatum">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Sensor"/>
+        <rdfs:range rdf:resource="http://rescue-mate.de/ontology/VerticalDatum"/>
+        <rdfs:comment xml:lang="de">Höhenbezug, auf den sich die Werte des Sensors beziehen. Ohne diese Angabe ist ein Wasserstand nicht mit einer Bauwerkshöhe vergleichbar, denn Pegelnull liegt je Pegel unterschiedlich tief unter Normalhöhennull.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Vertical datum the sensor's values refer to. Without it a water level cannot be compared to a structure height, since gauge zero sits at a different depth below normal height null at every gauge.</rdfs:comment>
+        <rdfs:label xml:lang="de">hat Höhenbezug</rdfs:label>
+        <rdfs:label xml:lang="en">has vertical datum</rdfs:label>
+    </owl:ObjectProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/measuredBySensor -->
+
+    <owl:ObjectProperty rdf:about="http://rescue-mate.de/ontology/measuredBySensor">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/SensorReading"/>
+        <rdfs:range rdf:resource="http://rescue-mate.de/ontology/Sensor"/>
+        <rdfs:comment xml:lang="de">Sensor, der diesen Messwert erzeugt hat. Einheit und Höhenbezug hängen am Sensor, nicht am Einzelwert, weil sie über die Zeitreihe konstant sind.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Sensor that produced this reading. Unit and vertical datum hang off the sensor rather than the individual reading, since they are constant across the time series.</rdfs:comment>
+        <rdfs:label xml:lang="de">gemessen von Sensor</rdfs:label>
+        <rdfs:label xml:lang="en">measured by sensor</rdfs:label>
+    </owl:ObjectProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/observesProperty -->
+
+    <owl:ObjectProperty rdf:about="http://rescue-mate.de/ontology/observesProperty">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Sensor"/>
+        <rdfs:range rdf:resource="http://rescue-mate.de/ontology/ObservedProperty"/>
+        <rdfs:comment xml:lang="de">Größe, die der Sensor misst.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Property the sensor observes.</rdfs:comment>
+        <rdfs:label xml:lang="de">misst Größe</rdfs:label>
+        <rdfs:label xml:lang="en">observes property</rdfs:label>
+    </owl:ObjectProperty>
+
+
+
+    <!--
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Data properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+
+
+
+    <!-- http://rescue-mate.de/ontology/gaugeZeroOffsetToNHNInCentimeters -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/gaugeZeroOffsetToNHNInCentimeters">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/MeasuringStation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:comment xml:lang="de">Tiefe des Pegelnullpunkts unter Normalhöhennull, in Zentimetern. Mit diesem Wert lässt sich jeder auf Pegelnull bezogene Wasserstand nach NHN umrechnen und damit mit Bauwerkshöhen vergleichen.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Depth of the gauge zero point below normal height null, in centimetres. With this value any water level given above gauge zero can be converted to NHN and thus compared to structure heights.</rdfs:comment>
+        <rdfs:label xml:lang="de">Pegelnull-Offset zu NHN in Zentimetern</rdfs:label>
+        <rdfs:label xml:lang="en">gauge zero offset to NHN in centimeters</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/meanHighTideLevelInCentimetersAboveGaugeZero -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/meanHighTideLevelInCentimetersAboveGaugeZero">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/MeasuringStation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:comment xml:lang="de">Mittleres Tidehochwasser (MTHw) an diesem Pegel, in Zentimetern über Pegelnull.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Mean high tide water level (MTHw) at this gauge, in centimetres above gauge zero.</rdfs:comment>
+        <rdfs:label xml:lang="de">mittleres Tidehochwasser in Zentimetern über Pegelnull</rdfs:label>
+        <rdfs:label xml:lang="en">mean high tide level in centimeters above gauge zero</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/meanLowTideLevelInCentimetersAboveGaugeZero -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/meanLowTideLevelInCentimetersAboveGaugeZero">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/MeasuringStation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:comment xml:lang="de">Mittleres Tideniedrigwasser (MTNw) an diesem Pegel, in Zentimetern über Pegelnull.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Mean low tide water level (MTNw) at this gauge, in centimetres above gauge zero.</rdfs:comment>
+        <rdfs:label xml:lang="de">mittleres Tideniedrigwasser in Zentimetern über Pegelnull</rdfs:label>
+        <rdfs:label xml:lang="en">mean low tide level in centimeters above gauge zero</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/measuredQuantityCode -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/measuredQuantityCode">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Sensor"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment xml:lang="de">Kennung der Messgröße, wie die Quelle sie vergibt, etwa H für Wasserstand oder VmF für die mittlere Strömungsgeschwindigkeit im Fahrwasser. Bewusst ein Literal und keine Klassenhierarchie, weil die Kennungen quellenspezifisch sind; die quellenneutrale Zuordnung leistet observesProperty.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Code of the measured quantity as the source assigns it, for example H for water level or VmF for mean current speed in the fairway. Deliberately a literal rather than a class hierarchy, since the codes are source specific; observesProperty carries the source neutral classification.</rdfs:comment>
+        <rdfs:label xml:lang="de">Messgrößenkennung</rdfs:label>
+        <rdfs:label xml:lang="en">measured quantity code</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/observedAt -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/observedAt">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/SensorReading"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+        <rdfs:comment xml:lang="de">Zeitpunkt der Messung. Bewusst xsd:dateTime und nicht dateTimeStamp: Virtuoso kennt dateTimeStamp nicht und laesst Zeitfilter darauf stillschweigend durchlaufen.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Point in time the reading was taken. Deliberately xsd:dateTime rather than dateTimeStamp: Virtuoso does not know dateTimeStamp and silently lets time filters on it pass everything.</rdfs:comment>
+        <rdfs:label xml:lang="de">gemessen um</rdfs:label>
+        <rdfs:label xml:lang="en">observed at</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/qualityCode -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/qualityCode">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/SensorReading"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+        <rdfs:comment xml:lang="de">Qualitätskennzeichen der Quelle. Wird nur angegeben, wenn es vom Regelfall abweicht, ein fehlendes Kennzeichen bedeutet also einen regulär gebildeten Wert. Negative Werte weisen auf nachträgliche Bildung, Korrektur oder eine fehlgeschlagene Prüfung hin.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Quality code as given by the source. Only stated when it deviates from the regular case, so an absent code means a regularly formed value. Negative values indicate retroactive formation, correction, or a failed verification.</rdfs:comment>
+        <rdfs:label xml:lang="de">Qualitätskennzeichen</rdfs:label>
+        <rdfs:label xml:lang="en">quality code</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/riverKilometer -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/riverKilometer">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/MeasuringStation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:comment xml:lang="de">Stromkilometer, an dem die Messstelle liegt.</rdfs:comment>
+        <rdfs:comment xml:lang="en">River kilometre the measuring station is located at.</rdfs:comment>
+        <rdfs:label xml:lang="de">Stromkilometer</rdfs:label>
+        <rdfs:label xml:lang="en">river kilometer</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/samplingIntervalInSeconds -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/samplingIntervalInSeconds">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/Sensor"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+        <rdfs:comment xml:lang="de">Zeitraster, in dem der Sensor Werte liefert, in Sekunden. Ein negativer Wert bedeutet, dass der Sensor kein festes Raster hat und ereignisgesteuert liefert. Das Raster der Quelle sagt nichts darüber, in welcher Auflösung Werte im Graphen abgelegt sind.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Time grid the sensor delivers values on, in seconds. A negative value means the sensor has no fixed grid and delivers on events. The source's grid says nothing about the resolution at which readings are stored in the graph.</rdfs:comment>
+        <rdfs:label xml:lang="de">Zeitraster in Sekunden</rdfs:label>
+        <rdfs:label xml:lang="en">sampling interval in seconds</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/severeStormSurgeLevelInCentimetersAboveGaugeZero -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/severeStormSurgeLevelInCentimetersAboveGaugeZero">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/MeasuringStation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:comment xml:lang="de">Wasserstand, ab dem an diesem Pegel von einer schweren Sturmflut gesprochen wird, in Zentimetern über Pegelnull.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Water level from which a severe storm surge is spoken of at this gauge, in centimetres above gauge zero.</rdfs:comment>
+        <rdfs:label xml:lang="de">schwere Sturmflut in Zentimetern über Pegelnull</rdfs:label>
+        <rdfs:label xml:lang="en">severe storm surge level in centimeters above gauge zero</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/stationShortCode -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/stationShortCode">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/MeasuringStation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment xml:lang="de">Kurzkennung des Orts, an dem die Messstelle steht, wie die Quelle sie führt.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Short code of the place the measuring station stands at, as kept by the source.</rdfs:comment>
+        <rdfs:label xml:lang="de">Ortskürzel der Messstelle</rdfs:label>
+        <rdfs:label xml:lang="en">station short code</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/stormSurgeLevelInCentimetersAboveGaugeZero -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/stormSurgeLevelInCentimetersAboveGaugeZero">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/MeasuringStation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:comment xml:lang="de">Wasserstand, ab dem an diesem Pegel von einer Sturmflut gesprochen wird, in Zentimetern über Pegelnull.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Water level from which a storm surge is spoken of at this gauge, in centimetres above gauge zero.</rdfs:comment>
+        <rdfs:label xml:lang="de">Sturmflut in Zentimetern über Pegelnull</rdfs:label>
+        <rdfs:label xml:lang="en">storm surge level in centimeters above gauge zero</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/verySevereStormSurgeLevelInCentimetersAboveGaugeZero -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/verySevereStormSurgeLevelInCentimetersAboveGaugeZero">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/MeasuringStation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:comment xml:lang="de">Wasserstand, ab dem an diesem Pegel von einer sehr schweren Sturmflut gesprochen wird, in Zentimetern über Pegelnull.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Water level from which a very severe storm surge is spoken of at this gauge, in centimetres above gauge zero.</rdfs:comment>
+        <rdfs:label xml:lang="de">sehr schwere Sturmflut in Zentimetern über Pegelnull</rdfs:label>
+        <rdfs:label xml:lang="en">very severe storm surge level in centimeters above gauge zero</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- http://rescue-mate.de/ontology/waterwaySection -->
+
+    <owl:DatatypeProperty rdf:about="http://rescue-mate.de/ontology/waterwaySection">
+        <rdfs:domain rdf:resource="http://rescue-mate.de/ontology/MeasuringStation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment xml:lang="de">Gewässerabschnitt, in dem die Messstelle liegt, etwa Norderelbe oder Köhlbrand.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Waterway section the measuring station lies in, for example Norderelbe or Köhlbrand.</rdfs:comment>
+        <rdfs:label xml:lang="de">Gewässerabschnitt</rdfs:label>
+        <rdfs:label xml:lang="en">waterway section</rdfs:label>
+    </owl:DatatypeProperty>
+
+
+
+    <!--
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+
+
+
+    <!-- http://rescue-mate.de/ontology/MeasuringStation -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/MeasuringStation">
+        <rdfs:subClassOf rdf:resource="http://rescue-mate.de/ontology/Facility"/>
+        <rdfs:comment xml:lang="de">Ortsfeste Anlage, an der ein oder mehrere Sensoren Umweltgrößen messen, etwa ein Pegel an der Elbe.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Stationary facility at which one or more sensors measure environmental quantities, for example a gauge on the Elbe.</rdfs:comment>
+        <rdfs:label xml:lang="de">Messstelle</rdfs:label>
+        <rdfs:label xml:lang="en">Measuring station</rdfs:label>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/ObservedProperty -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/ObservedProperty">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000019"/>
+        <rdfs:comment xml:lang="de">Größe, die ein Sensor misst, etwa Wasserstand oder Windgeschwindigkeit.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Quantity a sensor observes, for example water level or wind speed.</rdfs:comment>
+        <rdfs:label xml:lang="de">Messgröße</rdfs:label>
+        <rdfs:label xml:lang="en">Observed property</rdfs:label>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/Sensor -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/Sensor">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000030"/>
+        <rdfs:comment xml:lang="de">Gerät, das an einer Messstelle eine Größe misst und daraus eine Reihe von Messwerten erzeugt.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Device that measures a quantity at a measuring station and thereby produces a series of readings.</rdfs:comment>
+        <rdfs:label xml:lang="de">Sensor</rdfs:label>
+        <rdfs:label xml:lang="en">Sensor</rdfs:label>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/VerticalDatum -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/VerticalDatum">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000019"/>
+        <rdfs:comment xml:lang="de">Bezugsfläche, auf die Höhen- und Wasserstandsangaben bezogen sind.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Reference surface that height and water level values refer to.</rdfs:comment>
+        <rdfs:label xml:lang="de">Höhenbezug</rdfs:label>
+        <rdfs:label xml:lang="en">Vertical datum</rdfs:label>
+    </owl:Class>
+
+
+
+    <!-- http://rescue-mate.de/ontology/WaterLevelTendency -->
+
+    <owl:Class rdf:about="http://rescue-mate.de/ontology/WaterLevelTendency">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000019"/>
+        <rdfs:comment xml:lang="de">Richtung, in die sich ein Wasserstand entwickelt.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Direction in which a water level is developing.</rdfs:comment>
+        <rdfs:label xml:lang="de">Wasserstandstendenz</rdfs:label>
+        <rdfs:label xml:lang="en">Water level tendency</rdfs:label>
+    </owl:Class>
+
+
+
+    <!--
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+
+
+
+    <!-- http://rescue-mate.de/resource/airPressureObservedProperty -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/airPressureObservedProperty">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ObservedProperty"/>
+        <rdfs:label xml:lang="de">Luftdruck</rdfs:label>
+        <rdfs:label xml:lang="en">air pressure</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/airTemperatureObservedProperty -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/airTemperatureObservedProperty">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ObservedProperty"/>
+        <rdfs:label xml:lang="de">Lufttemperatur</rdfs:label>
+        <rdfs:label xml:lang="en">air temperature</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/chartDatumVerticalDatum -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/chartDatumVerticalDatum">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/VerticalDatum"/>
+        <rdfs:label xml:lang="de">Kartennull (KN)</rdfs:label>
+        <rdfs:label xml:lang="en">chart datum (KN)</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/conductivityObservedProperty -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/conductivityObservedProperty">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ObservedProperty"/>
+        <rdfs:label xml:lang="de">Leitfähigkeit</rdfs:label>
+        <rdfs:label xml:lang="en">conductivity</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/currentSpeedObservedProperty -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/currentSpeedObservedProperty">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ObservedProperty"/>
+        <rdfs:comment xml:lang="de">Strömungsgeschwindigkeit. Werte sind vorzeichenbehaftet: das Vorzeichen unterscheidet Flut- und Ebbstrom.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Current speed. Values are signed: the sign distinguishes flood current from ebb current.</rdfs:comment>
+        <rdfs:label xml:lang="de">Strömungsgeschwindigkeit</rdfs:label>
+        <rdfs:label xml:lang="en">current speed</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/dischargeObservedProperty -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/dischargeObservedProperty">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ObservedProperty"/>
+        <rdfs:label xml:lang="de">Durchfluss</rdfs:label>
+        <rdfs:label xml:lang="en">discharge</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/dissolvedOxygenObservedProperty -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/dissolvedOxygenObservedProperty">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ObservedProperty"/>
+        <rdfs:label xml:lang="de">Sauerstoffgehalt</rdfs:label>
+        <rdfs:label xml:lang="en">dissolved oxygen</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/fallingTendency -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/fallingTendency">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/WaterLevelTendency"/>
+        <rdfs:label xml:lang="de">fallend</rdfs:label>
+        <rdfs:label xml:lang="en">falling</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/gaugeZeroVerticalDatum -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/gaugeZeroVerticalDatum">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/VerticalDatum"/>
+        <rdfs:comment xml:lang="de">Pegelnull, der örtliche Nullpunkt eines Pegels. Liegt je Pegel unterschiedlich tief unter Normalhöhennull; der Abstand steht an der Messstelle als gaugeZeroOffsetToNHNInCentimeters.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Gauge zero, the local zero point of a gauge. Sits at a different depth below normal height null at every gauge; the distance is held on the measuring station as gaugeZeroOffsetToNHNInCentimeters.</rdfs:comment>
+        <rdfs:label xml:lang="de">Pegelnull (PN)</rdfs:label>
+        <rdfs:label xml:lang="en">gauge zero (PN)</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/lowestAstronomicalTideVerticalDatum -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/lowestAstronomicalTideVerticalDatum">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/VerticalDatum"/>
+        <rdfs:label xml:lang="de">Seekartennull (SKN)</rdfs:label>
+        <rdfs:label xml:lang="en">lowest astronomical tide (SKN)</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/nhnVerticalDatum -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/nhnVerticalDatum">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/VerticalDatum"/>
+        <rdfs:label xml:lang="de">Normalhöhennull (NHN)</rdfs:label>
+        <rdfs:label xml:lang="en">normal height null (NHN)</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/oxygenSaturationObservedProperty -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/oxygenSaturationObservedProperty">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ObservedProperty"/>
+        <rdfs:label xml:lang="de">Sauerstoffsättigung</rdfs:label>
+        <rdfs:label xml:lang="en">oxygen saturation</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/precipitationObservedProperty -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/precipitationObservedProperty">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ObservedProperty"/>
+        <rdfs:label xml:lang="de">Niederschlagsmenge</rdfs:label>
+        <rdfs:label xml:lang="en">precipitation</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/relativeHumidityObservedProperty -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/relativeHumidityObservedProperty">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ObservedProperty"/>
+        <rdfs:label xml:lang="de">relative Luftfeuchte</rdfs:label>
+        <rdfs:label xml:lang="en">relative humidity</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/risingTendency -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/risingTendency">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/WaterLevelTendency"/>
+        <rdfs:label xml:lang="de">steigend</rdfs:label>
+        <rdfs:label xml:lang="en">rising</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/salinityObservedProperty -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/salinityObservedProperty">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ObservedProperty"/>
+        <rdfs:label xml:lang="de">Salinität</rdfs:label>
+        <rdfs:label xml:lang="en">salinity</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/statusValueObservedProperty -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/statusValueObservedProperty">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ObservedProperty"/>
+        <rdfs:label xml:lang="de">Statuswert</rdfs:label>
+        <rdfs:label xml:lang="en">status value</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/steadyTendency -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/steadyTendency">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/WaterLevelTendency"/>
+        <rdfs:label xml:lang="de">gleichbleibend</rdfs:label>
+        <rdfs:label xml:lang="en">steady</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/timeValueObservedProperty -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/timeValueObservedProperty">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ObservedProperty"/>
+        <rdfs:label xml:lang="de">Zeitwert</rdfs:label>
+        <rdfs:label xml:lang="en">time value</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/turbidityObservedProperty -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/turbidityObservedProperty">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ObservedProperty"/>
+        <rdfs:label xml:lang="de">Trübung</rdfs:label>
+        <rdfs:label xml:lang="en">turbidity</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/visibilityObservedProperty -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/visibilityObservedProperty">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ObservedProperty"/>
+        <rdfs:label xml:lang="de">Sichtweite</rdfs:label>
+        <rdfs:label xml:lang="en">visibility</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/waterLevelObservedProperty -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/waterLevelObservedProperty">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ObservedProperty"/>
+        <rdfs:label xml:lang="de">Wasserstand</rdfs:label>
+        <rdfs:label xml:lang="en">water level</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/waterTemperatureObservedProperty -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/waterTemperatureObservedProperty">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ObservedProperty"/>
+        <rdfs:label xml:lang="de">Wassertemperatur</rdfs:label>
+        <rdfs:label xml:lang="en">water temperature</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/windDirectionObservedProperty -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/windDirectionObservedProperty">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ObservedProperty"/>
+        <rdfs:label xml:lang="de">Windrichtung</rdfs:label>
+        <rdfs:label xml:lang="en">wind direction</rdfs:label>
+    </owl:NamedIndividual>
+
+
+
+    <!-- http://rescue-mate.de/resource/windSpeedObservedProperty -->
+
+    <owl:NamedIndividual rdf:about="http://rescue-mate.de/resource/windSpeedObservedProperty">
+        <rdf:type rdf:resource="http://rescue-mate.de/ontology/ObservedProperty"/>
+        <rdfs:label xml:lang="de">Windgeschwindigkeit</rdfs:label>
+        <rdfs:label xml:lang="en">wind speed</rdfs:label>
+    </owl:NamedIndividual>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi -->


### PR DESCRIPTION
Adds `ontology/measurements.rdf` and imports it from `main.rdf`, so the graph can hold a measuring network: stations, their sensors, and the readings those sensors produce.

## Why

`rmo:SensorReading` has been in `main.rdf` from the start — a subclass of `IAO_0000109` with no properties and no instance anywhere. `toBeImplementedAtWaterLevelMark0..4` and `closedWaterLevelInMeters` have been there too, and they only mean something once a measured water level exists to compare them against. This is the missing half.

The first source is the HPA's HydroOnline network (97 stations on the Elbe: water level, current, wind, weather, water quality), but the module is named for measurements rather than for that source. A shared shape lets one query serve a rain radar or dike sensors later — the same reasoning that kept `Trajectory` domain neutral instead of adopting the maritime one from VesselAI.

## What is in it

| | |
|---|---|
| Classes | `MeasuringStation` ⊑ `Facility`, `Sensor` ⊑ `BFO_0000030`, `ObservedProperty` / `VerticalDatum` / `WaterLevelTendency` ⊑ `BFO_0000019` |
| Reused | `SensorReading` keeps its place under `IAO_0000109` and finally gets properties |
| Individuals | 18 observed properties, 4 vertical datums, 3 tendencies, all in `rmr:`, all with de+en labels |
| Properties | 5 object, 13 datatype |

Code lists follow the style of every 2026 addition: a `BFO_0000019` subclass with named individuals, not a class hierarchy.

## Decisions worth reviewing

**Unit and datum sit on the sensor, not on each reading.** They hold for the whole series. A network delivering by the minute would otherwise pay two triples per value for something that never changes.

**The gauge marks name their reference in the predicate** — `stormSurgeLevelInCentimetersAboveGaugeZero`, not `stormSurgeLevel`. Gauge zero sits at a different depth below NHN at every gauge, so a water level without its datum cannot be compared against `protectsUpToHeightInMetersAboveSeaLevel`, and that comparison is the point of importing the values at all. `gaugeZeroOffsetToNHNInCentimeters` on the station carries what is needed to convert.

**`observedAt` is `xsd:dateTime`, not `dateTimeStamp`** — the reason already recorded on `startedAt`: Virtuoso does not know `dateTimeStamp` and lets time filters on it silently pass everything.

**SOSA/SSN was deliberately not imported.** It would have been the obvious choice, but the ontology is BFO rooted throughout and imports no observation vocabulary; adding one for a single module would place two upper models side by side.

## Notes

- No `rdfs:seeAlso` links to Wikidata on the new individuals. They belong there by convention, but guessing QIDs would be worse than leaving them for someone who can check each one.
- Also fixes the typo in the English comment on `SensorReading` ("mesurement").
- Parsed with rdflib: 280 triples, every entity carries both a German and an English label.

## Depends on

Nothing. The consuming side is a separate merge request in `rescue-mate-platform`, which reads HydroOnline into these terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)